### PR TITLE
Use map for lookup of known extensions

### DIFF
--- a/extension/xml_test.go
+++ b/extension/xml_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestUpdateResponseMarshalXML(t *testing.T) {
+	allExtensionsMap := LoadExtensionsIntoMap(&OfferedExtensions)
 	// Empty extension list returns a blank XML update
 	updateResponse := UpdateResponse{}
 	xmlData, err := xml.Marshal(&updateResponse)
@@ -15,8 +16,8 @@ func TestUpdateResponseMarshalXML(t *testing.T) {
 	expectedOutput := `<response protocol="3.1" server="prod"></response>`
 	assert.Equal(t, expectedOutput, string(xmlData))
 
-	darkThemeExtension, err := OfferedExtensions.Contains("bfdgpgibhagkpdlnjonhkabjoijopoge")
-	assert.Nil(t, err)
+	darkThemeExtension, ok := allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	assert.True(t, ok)
 
 	// Single extension list returns a single XML update
 	updateResponse = []Extension{darkThemeExtension}
@@ -39,10 +40,10 @@ func TestUpdateResponseMarshalXML(t *testing.T) {
 	assert.Equal(t, expectedOutput, string(xmlData))
 
 	// Multiple extensions returns a multiple extension XML update
-	lightThemeExtension, err := OfferedExtensions.Contains("ldimlcelhnjgpjjemdjokpgeeikdinbm")
-	assert.Nil(t, err)
-	darkThemeExtension, err = OfferedExtensions.Contains("bfdgpgibhagkpdlnjonhkabjoijopoge")
-	assert.Nil(t, err)
+	lightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
+	assert.True(t, ok)
+	darkThemeExtension, ok = allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	assert.True(t, ok)
 	updateResponse = []Extension{lightThemeExtension, darkThemeExtension}
 	xmlData, err = xml.Marshal(&updateResponse)
 	assert.Nil(t, err)
@@ -130,13 +131,14 @@ func TestUpdateRequestUnmarshalXML(t *testing.T) {
 func TestWebStoreUpdateResponseMarshalXML(t *testing.T) {
 	// No extensions returns blank update response
 	updateResponse := WebStoreUpdateResponse{}
+	allExtensionsMap := LoadExtensionsIntoMap(&OfferedExtensions)
 	xmlData, err := xml.Marshal(&updateResponse)
 	assert.Nil(t, err)
 	expectedOutput := `<gupdate protocol="3.1" server="prod"></gupdate>`
 	assert.Equal(t, expectedOutput, string(xmlData))
 
-	darkThemeExtension, err := OfferedExtensions.Contains("bfdgpgibhagkpdlnjonhkabjoijopoge")
-	assert.Nil(t, err)
+	darkThemeExtension, ok := allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	assert.True(t, ok)
 
 	// Single extension list returns a single XML update
 	updateResponse = WebStoreUpdateResponse{darkThemeExtension}
@@ -150,10 +152,10 @@ func TestWebStoreUpdateResponseMarshalXML(t *testing.T) {
 	assert.Equal(t, expectedOutput, string(xmlData))
 
 	// Multiple extensions returns a multiple extension XML webstore update
-	lightThemeExtension, err := OfferedExtensions.Contains("ldimlcelhnjgpjjemdjokpgeeikdinbm")
-	assert.Nil(t, err)
-	darkThemeExtension, err = OfferedExtensions.Contains("bfdgpgibhagkpdlnjonhkabjoijopoge")
-	assert.Nil(t, err)
+	lightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
+	assert.True(t, ok)
+	darkThemeExtension, ok = allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	assert.True(t, ok)
 	updateResponse = WebStoreUpdateResponse{lightThemeExtension, darkThemeExtension}
 	xmlData, err = xml.Marshal(&updateResponse)
 	assert.Nil(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -238,6 +238,8 @@ func TestWebStoreUpdateExtension(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
+	allExtensionsMap := extension.LoadExtensionsIntoMap(&extension.OfferedExtensions)
+
 	// Empty query param request, no extensions.
 	requestBody := ""
 	query := ""
@@ -245,9 +247,9 @@ func TestWebStoreUpdateExtension(t *testing.T) {
 	testCall(t, server, http.MethodGet, query, requestBody, http.StatusOK, expectedResponse)
 
 	// Extension that we handle which is outdated should produce a response
-	outdatedLightThemeExtension, err := extension.OfferedExtensions.Contains("ldimlcelhnjgpjjemdjokpgeeikdinbm")
+	outdatedLightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
 	outdatedLightThemeExtension.Version = "0.0.0"
-	assert.Nil(t, err)
+	assert.True(t, ok)
 	query = "?" + getQueryParams(&outdatedLightThemeExtension)
 	expectedResponse = `<gupdate protocol="3.1" server="prod">
     <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm" status="ok">
@@ -257,9 +259,9 @@ func TestWebStoreUpdateExtension(t *testing.T) {
 	testCall(t, server, http.MethodGet, query, requestBody, http.StatusOK, expectedResponse)
 
 	// Multiple extensions that we handle which are outdated should produce a response
-	outdatedDarkThemeExtension, err := extension.OfferedExtensions.Contains("bfdgpgibhagkpdlnjonhkabjoijopoge")
+	outdatedDarkThemeExtension, ok := allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	assert.True(t, ok)
 	outdatedDarkThemeExtension.Version = "0.0.0"
-	assert.Nil(t, err)
 	query = "?" + getQueryParams(&outdatedLightThemeExtension) + "&" + getQueryParams(&outdatedDarkThemeExtension)
 	expectedResponse = `<gupdate protocol="3.1" server="prod">
     <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm" status="ok">
@@ -272,8 +274,8 @@ func TestWebStoreUpdateExtension(t *testing.T) {
 	testCall(t, server, http.MethodGet, query, requestBody, http.StatusOK, expectedResponse)
 
 	// Extension that we handle which is up to date should NOT produce an update but still be successful
-	lightThemeExtension, err := extension.OfferedExtensions.Contains("ldimlcelhnjgpjjemdjokpgeeikdinbm")
-	assert.Nil(t, err)
+	lightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
+	assert.True(t, ok)
 	query = "?" + getQueryParams(&lightThemeExtension)
 	expectedResponse = `<gupdate protocol="3.1" server="prod"></gupdate>`
 	testCall(t, server, http.MethodGet, query, requestBody, http.StatusOK, expectedResponse)


### PR DESCRIPTION
Fix #3 

This uses a map instead of a slice so that extensions can be looked up to see if there is a match by extension ID. 