### PR TITLE
Use DynamoDB for extensions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,140 +2,245 @@
 
 
 [[projects]]
+  digest = "1:3d9dda12326d4292459b9e2b3204c7b2262b92ea478399d7eeb0cbbb8c78accc"
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/sdkio",
+    "internal/sdkrand",
+    "internal/sdkuri",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/dynamodb",
+    "service/dynamodb/dynamodbattribute",
+    "service/sts",
+  ]
+  pruneopts = "UT"
+  revision = "04abd557eeaab3cfdded45467eea00fc03db9cb9"
+  version = "v1.15.26"
+
+[[projects]]
   branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "UT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:58f65aa9bf240e223b8a2a4749da527f7e2603a38cc6a1771afc6bb7388f1aba"
   name = "github.com/brave-intl/bat-go"
   packages = ["middleware"]
+  pruneopts = "UT"
   revision = "35cc073bfec0991990c54e29641c211d684ea0ae"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:fed1f537c2f1269fe475a8556c393fe466641682d73ef8fd0491cd3aa1e47bad"
   name = "github.com/certifi/gocertifi"
   packages = ["."]
+  pruneopts = "UT"
   revision = "deb3ae2ef2610fde3330947281941c562861188b"
   version = "2018.01.18"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:608d0fe1621755354728fbaeef8ada8b4a33001aec88b66c970e641be950d850"
   name = "github.com/getsentry/raven-go"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7535a8fa2ace0ffb684b19f28d00655459ea2dae"
 
 [[projects]]
+  digest = "1:4eda9f7bf70f5145b3b9ed3f18ac93e9b1a0e38906eb69e526380c34861e2b07"
   name = "github.com/go-chi/chi"
   packages = [
     ".",
-    "middleware"
+    "middleware",
   ]
+  pruneopts = "UT"
   revision = "e83ac2304db3c50cf03d96a2fcd39009d458bc35"
   version = "v3.3.2"
 
 [[projects]]
+  digest = "1:5abd6a22805b1919f6a6bca0ae58b13cef1f3412812f38569978f43ef02743d4"
+  name = "github.com/go-ini/ini"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5cf292cae48347c2490ac1a58fe36735fb78df7e"
+  version = "v1.38.2"
+
+[[projects]]
+  digest = "1:15042ad3498153684d09f393bbaec6b216c8eec6d61f63dff711de7d64ed8861"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = "UT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "0b12d6b5"
+
+[[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = "UT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:ad1646548f80ec14f44c927337238acedca5b1b430bb4e983f2b7b93102d2b66"
   name = "github.com/pressly/lg"
   packages = ["."]
+  pruneopts = "UT"
   revision = "bfbc64b4561fef198c68289c2610ccc4696d57d1"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:c968b29db5d68ec97de404b6d058d5937fa015a141b3b4f7a0d87d5f8226f04c"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
-    "prometheus/promhttp"
+    "prometheus/promhttp",
   ]
+  pruneopts = "UT"
   revision = "967789050ba94deca04a5e84cce8ad472ce313c1"
   version = "v0.9.0-pre1"
 
 [[projects]]
   branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = "UT"
   revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
 
 [[projects]]
   branch = "master"
+  digest = "1:63b68062b8968092eb86bedc4e68894bd096ea6b24920faca8b9dcf451f54bb5"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = "UT"
   revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
 
 [[projects]]
   branch = "master"
+  digest = "1:8c49953a1414305f2ff5465147ee576dd705487c35b15918fcd4efdc0cb7a290"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = "UT"
   revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
 
 [[projects]]
+  digest = "1:d867dfa6751c8d7a435821ad3b736310c2ed68945d05b50fb9d23aee0540c8cc"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "UT"
   revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
   version = "v1.0.6"
 
 [[projects]]
+  digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "UT"
   revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
 
 [[projects]]
   branch = "master"
+  digest = "1:4a7c38ff146e5002dda78fdf599ac143fd0c98ffba9fb9d1721c3ba7fcd356c0"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "UT"
   revision = "3dc4335d56c789b04b0ba99b7a37249d9b614314"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "283ba9b45b1457c31d0f19151366b50c55e29b56846fca22aad4322ea115db89"
+  input-imports = [
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/dynamodb",
+    "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute",
+    "github.com/brave-intl/bat-go/middleware",
+    "github.com/getsentry/raven-go",
+    "github.com/go-chi/chi",
+    "github.com/go-chi/chi/middleware",
+    "github.com/pressly/lg",
+    "github.com/sirupsen/logrus",
+    "github.com/stretchr/testify/assert",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,3 +25,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/getsentry/raven-go"
+
+[[constraint]]
+  name = "github.com/aws/aws-sdk-go"
+  version = "1.15.26"

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -86,7 +86,32 @@ func ExtensionsRouter(extensions extension.Extensions) chi.Router {
 	r := chi.NewRouter()
 	r.Post("/", UpdateExtensions)
 	r.Get("/", WebStoreUpdateExtension)
+	r.Get("/test", PrintExtensions)
 	return r
+}
+
+// PrintExtensions is just used for troubleshooting to see what the internal list of extensions DB holds
+// It simply prints out text for all extensions when visiting /extensions/test.
+// Since our internally maintained list is always small by design, this is not a big deal for performance.
+func PrintExtensions(w http.ResponseWriter, r *http.Request) {
+	log := lg.Log(r.Context())
+	w.Header().Set("content-type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	if len(AllExtensionsMap) == 0 {
+		_, err := w.Write([]byte("No extensions found, do you have the AWS config correct for DynamoDB?"))
+		if err != nil {
+			log.Errorf("Error writing response for printing extensions: %v", err)
+		}
+		return
+	}
+	for key, val := range AllExtensionsMap {
+		s := fmt.Sprintf("%s=%+v\n\n", key, val)
+		_, err := w.Write([]byte(s))
+		if err != nil {
+			log.Errorf("Error writing response for printing extensions: %v", err)
+			break
+		}
+	}
 }
 
 // WebStoreUpdateExtension is the handler for updating extensions made via the GET HTTP methhod.

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -3,21 +3,86 @@ package controller
 import (
 	"encoding/xml"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/brave/go-update/extension"
+	"github.com/getsentry/raven-go"
 	"github.com/go-chi/chi"
 	"github.com/pressly/lg"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
-var allExtensionsMap = map[string]extension.Extension{}
+// AllExtensionsMap holds a mapping of extension ID to extension object.
+// This list for tests is populated by extensions.OfferedExtensions.
+// For normal operaitons of this server it is obtained from the AWS config
+// of the host machine for DynamoDB.
+var AllExtensionsMap = map[string]extension.Extension{}
+
+// ExtensionUpdaterTimeout is the amount of time to wait between getting new updates from DynamoDB for the list of extensions
+var ExtensionUpdaterTimeout = time.Minute * 10
+
+func initExtensionUpdatesFromDynamoDB() {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-2")},
+	)
+
+	if err != nil {
+		log.Printf("failed to connect to new session %v\n", err)
+		raven.CaptureError(err, nil)
+		return
+	}
+
+	// Create DynamoDB client
+	svc := dynamodb.New(sess)
+	params := &dynamodb.ScanInput{
+		TableName: aws.String("Extensions"),
+	}
+
+	// For most use cases, you probably wouldn't want to scan all entries; however,
+	// for our use case we have a read only small number of items, that are infrequently
+	// updated, usually less than daily by an external tool, and very often queried.
+	result, err := svc.Scan(params)
+	if err != nil {
+		log.Printf("failed to make Scan API call %v\n", err)
+		raven.CaptureError(err, nil)
+		return
+	}
+
+	// Update the extensions map
+	for _, item := range result.Items {
+		id := *item["ID"].S
+		AllExtensionsMap[id] = extension.Extension{
+			ID:          id,
+			Blacklisted: *item["Disabled"].BOOL,
+			SHA256:      *item["SHA256"].S,
+			Title:       *item["Title"].S,
+			Version:     *item["Version"].S,
+		}
+	}
+}
+
+// RefreshExtensionsTicker updates the list of extensions by
+// calling the specified extensionMapUpdater function
+func RefreshExtensionsTicker(extensionMapUpdater func()) {
+	extensionMapUpdater()
+	ticker := time.NewTicker(ExtensionUpdaterTimeout)
+	go func() {
+		for range ticker.C {
+			extensionMapUpdater()
+		}
+	}()
+}
 
 // ExtensionsRouter is the router for /extensions endpoints
 func ExtensionsRouter(extensions extension.Extensions) chi.Router {
-	allExtensionsMap = extension.LoadExtensionsIntoMap(&extensions)
+	RefreshExtensionsTicker(initExtensionUpdatesFromDynamoDB)
 	r := chi.NewRouter()
 	r.Post("/", UpdateExtensions)
 	r.Get("/", WebStoreUpdateExtension)
@@ -58,7 +123,7 @@ func WebStoreUpdateExtension(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		foundExtension, ok := allExtensionsMap[id]
+		foundExtension, ok := AllExtensionsMap[id]
 		if !ok && len(xValues) == 1 {
 			http.Redirect(w, r, "https://clients2.google.com/service/update2/crx?"+r.URL.RawQuery+"&braveRedirect=true", http.StatusTemporaryRedirect)
 			return
@@ -115,7 +180,7 @@ func UpdateExtensions(w http.ResponseWriter, r *http.Request) {
 	// Special case, if there's only 1 extension in the request and it is not something
 	// we know about, redirect the client to google component update server.
 	if len(updateRequest) == 1 {
-		_, ok := allExtensionsMap[updateRequest[0].ID]
+		_, ok := AllExtensionsMap[updateRequest[0].ID]
 		if !ok {
 			http.Redirect(w, r, "https://update.googleapis.com/service/update2?braveRedirect=true", http.StatusTemporaryRedirect)
 			return
@@ -123,7 +188,7 @@ func UpdateExtensions(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("content-type", "application/xml")
 	w.WriteHeader(http.StatusOK)
-	updateResponse := updateRequest.FilterForUpdates(&allExtensionsMap)
+	updateResponse := updateRequest.FilterForUpdates(&AllExtensionsMap)
 	data, err := xml.Marshal(&updateResponse)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error in marshal XML %v", err), http.StatusInternalServerError)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"github.com/brave/go-update/controller"
 	"github.com/brave/go-update/extension"
 	"github.com/brave/go-update/extension/extensiontest"
 	"github.com/go-chi/chi"
@@ -14,12 +15,46 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
+var newExtension1 = extension.Extension{}
+var newExtension2 = extension.Extension{}
 var handler http.Handler
 
 func init() {
+	newExtensionID1 := "newext1eplbcioakkpcpgfkobkghlhen"
+	newExtension1 = extension.Extension{
+		ID:          newExtensionID1,
+		Blacklisted: false,
+		SHA256:      "4c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618",
+		Title:       "test",
+		Version:     "1.0.0",
+	}
+	newExtensionID2 := "newext2eplbcioakkpcpgfkobkghlhen"
+	newExtension2 = extension.Extension{
+		ID:          newExtensionID2,
+		Blacklisted: false,
+		SHA256:      "3c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618",
+		Title:       "test",
+		Version:     "1.0.0",
+	}
+
+	// Setup refreshing extensions with a new extension that we'll check for later
+	// We maintain a count to make sure the refresh function is called more than just
+	// the first time.
+	count := 0
+	controller.AllExtensionsMap = extension.LoadExtensionsIntoMap(&extension.OfferedExtensions)
+	controller.ExtensionUpdaterTimeout = time.Millisecond * 1
 	handler = chi.ServerBaseContext(setupRouter(setupLogger(context.Background())))
+	controller.RefreshExtensionsTicker(func() {
+		count++
+		if count == 1 {
+			controller.AllExtensionsMap[newExtensionID1] = newExtension1
+		} else if count == 2 {
+			controller.AllExtensionsMap[newExtensionID2] = newExtension2
+		}
+	})
 }
 
 func TestPing(t *testing.T) {
@@ -228,6 +263,42 @@ func TestUpdateExtensions(t *testing.T) {
 	requestBody = string(data)
 	expectedResponse = "Request too large"
 	testCall(t, server, http.MethodPost, "", requestBody, http.StatusBadRequest, expectedResponse)
+
+	// Single new extension out of date that was added in by the refresh timer
+	requestBody = extensiontest.ExtensionRequestFnFor("newext1eplbcioakkpcpgfkobkghlhen")("0.0.0")
+	expectedResponse = `<response protocol="3.1" server="prod">
+    <app appid="newext1eplbcioakkpcpgfkobkghlhen">
+        <updatecheck status="ok">
+            <urls>
+                <url codebase="https://s3.amazonaws.com/brave-extensions/release/newext1eplbcioakkpcpgfkobkghlhen/extension_1_0_0.crx"></url>
+            </urls>
+            <manifest version="1.0.0">
+                <packages>
+                    <package name="extension_1_0_0.crx" hash_sha256="4c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618" required="true"></package>
+                </packages>
+            </manifest>
+        </updatecheck>
+    </app>
+</response>`
+	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse)
+
+	// Single second new extension out of date that was added in by the refresh timer
+	requestBody = extensiontest.ExtensionRequestFnFor("newext2eplbcioakkpcpgfkobkghlhen")("0.0.0")
+	expectedResponse = `<response protocol="3.1" server="prod">
+    <app appid="newext2eplbcioakkpcpgfkobkghlhen">
+        <updatecheck status="ok">
+            <urls>
+                <url codebase="https://s3.amazonaws.com/brave-extensions/release/newext2eplbcioakkpcpgfkobkghlhen/extension_1_0_0.crx"></url>
+            </urls>
+            <manifest version="1.0.0">
+                <packages>
+                    <package name="extension_1_0_0.crx" hash_sha256="3c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618" required="true"></package>
+                </packages>
+            </manifest>
+        </updatecheck>
+    </app>
+</response>`
+	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse)
 }
 
 func getQueryParams(extension *extension.Extension) string {


### PR DESCRIPTION
This PR does 2 things:

1) Adds a timer to refresh the list of extensions from DynamoDB
2)Adds an API to print all extensions that the server knows about

Since a LOT of clients query for extensions, and the list of extensions is small. It is better to cache the extension list in a map locally and periodically refresh it. 

DynamoDB is populated by a separate Node packaging script here https://github.com/brave/brave-core-crx-packager/commit/842199aa8e8e8127634fdf20e19db1b5aa1fbbc7