### PR TITLE
Don't strip query param from update.googleapis.com requests

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -207,7 +207,7 @@ func UpdateExtensions(w http.ResponseWriter, r *http.Request) {
 	if len(updateRequest) == 1 {
 		_, ok := AllExtensionsMap[updateRequest[0].ID]
 		if !ok {
-			http.Redirect(w, r, "https://update.googleapis.com/service/update2?braveRedirect=true", http.StatusTemporaryRedirect)
+			http.Redirect(w, r, "https://update.googleapis.com/service/update2?"+r.URL.RawQuery+"&braveRedirect=true", http.StatusTemporaryRedirect)
 			return
 		}
 	}


### PR DESCRIPTION
Potential fix for https://github.com/brave/brave-browser/issues/1773

WARNING - i don't have my golang environment set up yet so i haven't tested this