### PR TITLE
Fixed Dockerfile in order to deploy a functioning go-updater

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,19 @@ ENV DEP_SHA256SUM 287b08291e14f1fae8ba44374b26a2b12eb941af3497ed0ca649253e21ba2f
 RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v$DEP_VERSION/dep-linux-amd64
 RUN echo "$DEP_SHA256SUM  /usr/local/bin/dep" | shasum -a 256 -c
 RUN chmod +x /usr/local/bin/dep
+RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 
 FROM golang:1.10 as builder
 WORKDIR /go/src/app
 
 COPY --from=dep /usr/local/bin/dep /usr/local/bin/dep
+COPY --from=dep /go/bin/golangci-lint /bin/golangci-lint
 COPY . .
 RUN dep ensure
-ENTRYPOINT ["/usr/bin/make"]
-CMD ["build"]
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 
-
-FROM alpine:3.8 as app
+FROM alpine:latest as app
 RUN apk add --update ca-certificates # Certificates for SSL
 COPY --from=builder  /go/src/app .
+CMD ["./main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=dep /usr/local/bin/dep /usr/local/bin/dep
 COPY --from=dep /go/bin/golangci-lint /bin/golangci-lint
 COPY . .
 RUN dep ensure
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
+RUN /usr/bin/make build
 
 FROM alpine:latest as app
 RUN apk add --update ca-certificates # Certificates for SSL

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: lint test build
 
 build:
-	go run main.go
+	env CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 
 test:
 	go test -v ./...

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ dep ensure
 
 `make test`
 
+## Build go-update:
+
+`make build`
+
 ## Run go-update:
 
-`make`
+`./main`


### PR DESCRIPTION
Updated ```Dockerfile``` so that when ```docker-compose up``` is used, the ```go-updater``` application will be deployed.