### PR TITLE
Return appid with an update-status noupdate if component is up to date

### DIFF
--- a/extension/extension.go
+++ b/extension/extension.go
@@ -14,6 +14,7 @@ type Extension struct {
 	Title       string
 	URL         string
 	Blacklisted bool
+	Status      string
 }
 
 // Extensions is type for a slice of Extension.
@@ -76,7 +77,11 @@ func (updateRequest *UpdateRequest) FilterForUpdates(allExtensionsMap *map[strin
 	for _, extensionBeingChecked := range *updateRequest {
 		foundExtension, ok := (*allExtensionsMap)[extensionBeingChecked.ID]
 		if ok {
-			if !foundExtension.Blacklisted && CompareVersions(extensionBeingChecked.Version, foundExtension.Version) < 0 {
+			status := CompareVersions(extensionBeingChecked.Version, foundExtension.Version)
+			if !foundExtension.Blacklisted && status <= 0 {
+				if status == 0 {
+					foundExtension.Status = "noupdate"
+				}
 				filteredExtensions = append(filteredExtensions, foundExtension)
 			}
 		}

--- a/extension/xml.go
+++ b/extension/xml.go
@@ -6,6 +6,14 @@ import (
 	"strings"
 )
 
+// UpdateStatus returns the status of an update response for an extension
+func UpdateStatus(extension Extension) string {
+	if extension.Status == "" {
+		return "ok"
+	}
+	return extension.Status
+}
+
 // MarshalXML encodes the extension list into response XML
 func (updateResponse *UpdateResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	type URL struct {
@@ -53,7 +61,7 @@ func (updateResponse *UpdateResponse) MarshalXML(e *xml.Encoder, start xml.Start
 	response.Server = "prod"
 	for _, extension := range *updateResponse {
 		app := App{AppID: extension.ID}
-		app.UpdateCheck = UpdateCheck{Status: "ok"}
+		app.UpdateCheck = UpdateCheck{Status: UpdateStatus(extension)}
 		extensionName := "extension_" + strings.Replace(extension.Version, ".", "_", -1) + ".crx"
 		url := "https://brave-core-ext.s3.brave.com/release/" + extension.ID + "/" + extensionName
 		app.UpdateCheck.URLs.URLs = append(app.UpdateCheck.URLs.URLs, URL{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -170,7 +170,20 @@ func TestUpdateExtensions(t *testing.T) {
 
 	// Single extension same version
 	requestBody = lightThemeExtension("1.0.0")
-	expectedResponse = "<response protocol=\"3.1\" server=\"prod\"></response>"
+	expectedResponse = `<response protocol="3.1" server="prod">
+    <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm">
+        <updatecheck status="noupdate">
+            <urls>
+                <url codebase="https://brave-core-ext.s3.brave.com/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"></url>
+            </urls>
+            <manifest version="1.0.0">
+                <packages>
+                    <package name="extension_1_0_0.crx" hash_sha256="1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618" required="true"></package>
+                </packages>
+            </manifest>
+        </updatecheck>
+    </app>
+</response>`
 	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Single extension greater version


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1319

## Description

Component updater expects `appid` and update-status `noupdate` if the component is up to date. If `appid` and `update-status` are not present in the response from the go-updater,  `UpdateCheckResult` for the component is set to `UPDATE_RESPONSE_NOT_FOUND` showing an error on the `brave://components` screen.
(https://cs.chromium.org/chromium/src/components/update_client/update_engine.cc?l=262)

### Before the fix:

<img width="612" alt="screen shot 2019-01-23 at 5 53 28 pm" src="https://user-images.githubusercontent.com/1903815/51649115-fd02eb00-1f37-11e9-8797-b9736c59e76c.png">

### After the fix:
<img width="588" alt="screen shot 2019-01-23 at 5 54 10 pm" src="https://user-images.githubusercontent.com/1903815/51649127-02f8cc00-1f38-11e9-9c6d-ba10a6ed3f03.png">

Please feel free to reach out if you have any questions.

auditors: @bsclifton, @bbondy

## Test Plan:

1. Component Install:

- Open Brave with a clean new profile
- [x] Navigate to `brave://components` and verify if all the components are installed correctly.

2. Component Updates:

- [x] Relaunch brave and verify that no component is showing a `Update Error`

3. Individual Updates:

- [x] Click on `Check for update` on individual components and verify no error is shown
    - [x] Brave Component
    - [x] Chromium Component

4. New Extensions:

- [x] Install any extension and verify it's working correctly

5. Update Extensions (update available) - Wait for Adblock to update

- [x] Wait for a component update and verify that the component is updated successfully.

6. Update Error
- [x] Turned off the go-update server, and verified that the components were not updating with the correct status `Update Error` 

## Known failures

1. https://github.com/brave/brave-browser/issues/3093 - DCHECK failure on extension install (repros on master)