### PR TITLE
Issue 13: Using local test data to avoid test failures on component updates

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -81,8 +81,11 @@ func RefreshExtensionsTicker(extensionMapUpdater func()) {
 }
 
 // ExtensionsRouter is the router for /extensions endpoints
-func ExtensionsRouter(extensions extension.Extensions) chi.Router {
-	RefreshExtensionsTicker(initExtensionUpdatesFromDynamoDB)
+func ExtensionsRouter(extensions extension.Extensions, testRouter bool) chi.Router {
+	if !testRouter {
+		RefreshExtensionsTicker(initExtensionUpdatesFromDynamoDB)
+	}
+
 	r := chi.NewRouter()
 	r.Post("/", UpdateExtensions)
 	r.Get("/", WebStoreUpdateExtension)

--- a/server/server.go
+++ b/server/server.go
@@ -26,7 +26,7 @@ func setupLogger(ctx context.Context) (context.Context, *logrus.Logger) {
 	return ctx, logger
 }
 
-func setupRouter(ctx context.Context, logger *logrus.Logger) (context.Context, *chi.Mux) {
+func setupRouter(ctx context.Context, logger *logrus.Logger, testRouter bool) (context.Context, *chi.Mux) {
 	r := chi.NewRouter()
 	r.Use(chiware.RequestID)
 	r.Use(chiware.RealIP)
@@ -38,7 +38,7 @@ func setupRouter(ctx context.Context, logger *logrus.Logger) (context.Context, *
 		r.Use(middleware.RequestLogger(logger))
 	}
 	extensions := extension.OfferedExtensions
-	r.Mount("/extensions", controller.ExtensionsRouter(extensions))
+	r.Mount("/extensions", controller.ExtensionsRouter(extensions, testRouter))
 	r.Get("/metrics", middleware.Metrics())
 	return ctx, r
 }
@@ -47,7 +47,7 @@ func setupRouter(ctx context.Context, logger *logrus.Logger) (context.Context, *
 func StartServer() {
 	serverCtx, logger := setupLogger(context.Background())
 	logger.WithFields(logrus.Fields{"prefix": "main"}).Info("Starting server")
-	serverCtx, r := setupRouter(serverCtx, logger)
+	serverCtx, r := setupRouter(serverCtx, logger, false)
 	port := ":8192"
 	fmt.Printf("Starting server: http://localhost%s", port)
 	srv := http.Server{Addr: port, Handler: chi.ServerBaseContext(serverCtx, r)}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -46,7 +46,8 @@ func init() {
 	count := 0
 	controller.AllExtensionsMap = extension.LoadExtensionsIntoMap(&extension.OfferedExtensions)
 	controller.ExtensionUpdaterTimeout = time.Millisecond * 1
-	handler = chi.ServerBaseContext(setupRouter(setupLogger(context.Background())))
+	testCtx, logger := setupLogger(context.Background())
+	handler = chi.ServerBaseContext(setupRouter(testCtx, logger, true))
 	controller.RefreshExtensionsTicker(func() {
 		count++
 		if count == 1 {


### PR DESCRIPTION
fix https://github.com/brave/go-update/issues/13

## Description

`server_tests` fail when components like to Light/Dark theme are updated since it uses real-time data if the aws config is set correctly. Updating the tests to use local data when tests are executed. This avoids confusion on test failure if the aws config is set correctly.

auditors: @bbondy

## Test Plan

- [x] Run make test
- [x] All tests should pass
- [x] Verify the components are installed correctly in Brave