### PR TITLE
Issue 15: Set the fallback URL for google extensions/components to componentupdater.brave.com.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -214,7 +214,7 @@ func UpdateExtensions(w http.ResponseWriter, r *http.Request) {
 			if len(r.URL.RawQuery) != 0 {
 				queryString = r.URL.RawQuery + "&" + queryString
 			}
-			http.Redirect(w, r, "https://update.googleapis.com/service/update2?"+queryString, http.StatusTemporaryRedirect)
+			http.Redirect(w, r, "https://componentupdater.brave.com/service/update2?"+queryString, http.StatusTemporaryRedirect)
 			return
 		}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -265,15 +265,16 @@ func TestUpdateExtensions(t *testing.T) {
 </response>`
 	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse, "")
 
-	// Unkonwn extension ID goes to Google server
+	// Unkonwn extension ID goes to Google server via componentupdater proxy
 	requestBody = extensiontest.ExtensionRequestFnFor("aaaaaaaaaaaaaaaaaaaa")("0.0.0")
 	expectedResponse = ""
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://update.googleapis.com/service/update2?braveRedirect=true")
+	testCall(t, server, http.MethodPost, "", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2?braveRedirect=true")
 
-	// Unkonwn extension ID goes to Google server and preserves queyr params
+	// Unkonwn extension ID goes to Google server via componentupdater proxy
+	// and preserves query params
 	requestBody = extensiontest.ExtensionRequestFnFor("aaaaaaaaaaaaaaaaaaaa")("0.0.0")
 	expectedResponse = ""
-	testCall(t, server, http.MethodPost, "?test=hi", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://update.googleapis.com/service/update2?test=hi&braveRedirect=true")
+	testCall(t, server, http.MethodPost, "?test=hi", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2?test=hi&braveRedirect=true")
 
 	// Make sure a huge request body does not crash the server
 	data := make([]byte, 1024*1024*11) // 11 MiB


### PR DESCRIPTION
### Description

CRLSets which is maintained by google will be enabled by default in Brave to handle revoked certificates on all platforms. To prevent any connections to google servers by default we are setting the fallback URL for google extensions and components to componentupdater.brave.com which removes any user identifiable information before forwarding the requests to the google component update server.

More details here: https://github.com/brave/brave-browser/issues/518

auditors: @bbondy, @bsclifton, @diracdeltas

CRLSets PR: https://github.com/brave/brave-core/pull/1581

Feel free to DM if you need more info.

### Test Plan

- Before CRLSets
  - MacOS: 
    - [x] Default extensions installed at start
    - [x] No connections by default to Google servers
    - [x] Brave component updates work
    - [x] Individual component updates work
    - [x] No component status errors on restart
    - [x] Errors when go-updater is stopped
    - [x] New extensions installed correctly
    - [x] Updating extensions works correctly

  - Linux: 
    - [x] Default extensions installed at start
    - [x] No connections by default to Google servers
    - [x] Brave component updates work
    - [x] Individual component updates work
    - [x] No component status errors on restart
    - [x] Errors when go-updater is stopped
    - [x] New extensions installed correctly
    - [x] Updating extensions works correctly

  - Windows: 
    - [x] Default extensions installed at start
    - [x] No connections by default to Google servers
    - [x] Brave component updates work
    - [x] Individual component updates work
    - [x] No component status errors on restart
    - [x] Errors when go-updater is stopped
    - [x] New extensions installed correctly
    - [x] Updating extensions works correctly

- After CRLSets
  - MacOS: 
    - [x] Default extensions installed at start
    - [x] No connections by default to Google servers
    - [x] Brave component updates work
    - [x] Individual component updates work
    - [x] No component status errors on restart
    - [x] Errors when go-updater is stopped
    - [x] New extensions installed correctly
    - [x] Updating extensions works correctly

  - Linux: 
    - [x] Default extensions installed at start
    - [x] No connections by default to Google servers
    - [x] Brave component updates work
    - [x] Individual component updates work
    - [x] No component status errors on restart
    - [x] Errors when go-updater is stopped
    - [x] New extensions installed correctly
    - [x] Updating extensions works correctly

  - Windows: 
    - [x] Default extensions installed at start
    - [x] No connections by default to Google servers
    - [x] Brave component updates work
    - [x] Individual component updates work
    - [x] No component status errors on restart
    - [x] Errors when go-updater is stopped
    - [x] New extensions installed correctly
    - [x] Updating extensions works correctly
