### PR TITLE
Issue 18: Use dev instances of S3 buckets for components in dev environments

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  app:
+    build: .
+    environment:
+      - S3_EXTENSIONS_BUCKET_HOST=brave-core-ext-dev.s3.bravesoftware.com
+    ports:
+      - "80:8192"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  app:
+    build: .
+    environment:
+      - S3_EXTENSIONS_BUCKET_HOST=brave-core-ext.s3.brave.com
+    ports:
+      - "80:8192"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,0 @@
-version: '3'
-services:
-  app:
-    build: .
-    ports:
-      - "80:8192"

--- a/extension/xml.go
+++ b/extension/xml.go
@@ -3,8 +3,18 @@ package extension
 import (
 	"encoding/xml"
 	"fmt"
+	"os"
 	"strings"
 )
+
+// GetS3ExtensionBucketHost returns the bucket to use for accessing the crx files
+func GetS3ExtensionBucketHost() string {
+	s3BucketHost, ok := os.LookupEnv("S3_EXTENSIONS_BUCKET_HOST")
+	if !ok {
+		s3BucketHost = "brave-core-ext.s3.brave.com"
+	}
+	return s3BucketHost
+}
 
 // UpdateStatus returns the status of an update response for an extension
 func UpdateStatus(extension Extension) string {
@@ -63,7 +73,7 @@ func (updateResponse *UpdateResponse) MarshalXML(e *xml.Encoder, start xml.Start
 		app := App{AppID: extension.ID}
 		app.UpdateCheck = UpdateCheck{Status: UpdateStatus(extension)}
 		extensionName := "extension_" + strings.Replace(extension.Version, ".", "_", -1) + ".crx"
-		url := "https://brave-core-ext.s3.brave.com/release/" + extension.ID + "/" + extensionName
+		url := "https://" + GetS3ExtensionBucketHost() + "/release/" + extension.ID + "/" + extensionName
 		app.UpdateCheck.URLs.URLs = append(app.UpdateCheck.URLs.URLs, URL{
 			Codebase: url,
 		})
@@ -117,7 +127,7 @@ func (updateResponse *WebStoreUpdateResponse) MarshalXML(e *xml.Encoder, start x
 				Status:   "ok",
 				SHA256:   extension.SHA256,
 				Version:  extension.Version,
-				Codebase: "https://brave-core-ext.s3.brave.com/release/" + extension.ID + "/" + extensionName,
+				Codebase: "https://" + GetS3ExtensionBucketHost() + "/release/" + extension.ID + "/" + extensionName,
 			},
 		}
 		response.Apps = append(response.Apps, app)

--- a/extension/xml_test.go
+++ b/extension/xml_test.go
@@ -27,7 +27,7 @@ func TestUpdateResponseMarshalXML(t *testing.T) {
     <app appid="bfdgpgibhagkpdlnjonhkabjoijopoge">
         <updatecheck status="ok">
             <urls>
-                <url codebase="https://brave-core-ext.s3.brave.com/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"></url>
+                <url codebase="https://` + GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"></url>
             </urls>
             <manifest version="1.0.0">
                 <packages>
@@ -51,7 +51,7 @@ func TestUpdateResponseMarshalXML(t *testing.T) {
     <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm">
         <updatecheck status="ok">
             <urls>
-                <url codebase="https://brave-core-ext.s3.brave.com/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"></url>
+                <url codebase="https://` + GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"></url>
             </urls>
             <manifest version="1.0.0">
                 <packages>
@@ -63,7 +63,7 @@ func TestUpdateResponseMarshalXML(t *testing.T) {
     <app appid="bfdgpgibhagkpdlnjonhkabjoijopoge">
         <updatecheck status="ok">
             <urls>
-                <url codebase="https://brave-core-ext.s3.brave.com/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"></url>
+                <url codebase="https://` + GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"></url>
             </urls>
             <manifest version="1.0.0">
                 <packages>
@@ -146,7 +146,7 @@ func TestWebStoreUpdateResponseMarshalXML(t *testing.T) {
 	assert.Nil(t, err)
 	expectedOutput = `<gupdate protocol="3.1" server="prod">
     <app appid="bfdgpgibhagkpdlnjonhkabjoijopoge" status="ok">
-        <updatecheck status="ok" codebase="https://brave-core-ext.s3.brave.com/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx" version="1.0.0" hash_sha256="ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834"></updatecheck>
+        <updatecheck status="ok" codebase="https://` + GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx" version="1.0.0" hash_sha256="ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834"></updatecheck>
     </app>
 </gupdate>`
 	assert.Equal(t, expectedOutput, string(xmlData))
@@ -161,10 +161,10 @@ func TestWebStoreUpdateResponseMarshalXML(t *testing.T) {
 	assert.Nil(t, err)
 	expectedOutput = `<gupdate protocol="3.1" server="prod">
     <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm" status="ok">
-        <updatecheck status="ok" codebase="https://brave-core-ext.s3.brave.com/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx" version="1.0.0" hash_sha256="1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618"></updatecheck>
+        <updatecheck status="ok" codebase="https://` + GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx" version="1.0.0" hash_sha256="1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618"></updatecheck>
     </app>
     <app appid="bfdgpgibhagkpdlnjonhkabjoijopoge" status="ok">
-        <updatecheck status="ok" codebase="https://brave-core-ext.s3.brave.com/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx" version="1.0.0" hash_sha256="ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834"></updatecheck>
+        <updatecheck status="ok" codebase="https://` + GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx" version="1.0.0" hash_sha256="ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834"></updatecheck>
     </app>
 </gupdate>`
 	assert.Equal(t, expectedOutput, string(xmlData))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -123,7 +123,7 @@ func TestUpdateExtensions(t *testing.T) {
 		`<?xml version="1.0" encoding="UTF-8"?>
 		<request protocol="2.0" version="chrome-53.0.2785.116" prodversion="53.0.2785.116" requestid="{b4f77b70-af29-462b-a637-8a3e4be5ecd9}" lang="" updaterchannel="stable" prodchannel="stable" os="mac" arch="x64" nacl_arch="x86-64">
 			<app appid="aomjjhallfgjeglblehebfpbcfeobpgk">
-				<updatecheck codebase="https://brave-core-ext.s3.brave.com/release/aomjjhallfgjeglblehebfpbcfeobpgk/extension_4_5_9_90.crx" version="4.5.9.90"/>
+				<updatecheck codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/aomjjhallfgjeglblehebfpbcfeobpgk/extension_4_5_9_90.crx" version="4.5.9.90"/>
 			</app>
 		</request>`
 	expectedResponse = "Error reading body request version: 2.0 not supported"
@@ -157,7 +157,7 @@ func TestUpdateExtensions(t *testing.T) {
     <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm">
         <updatecheck status="ok">
             <urls>
-                <url codebase="https://brave-core-ext.s3.brave.com/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"></url>
+                <url codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"></url>
             </urls>
             <manifest version="1.0.0">
                 <packages>
@@ -175,7 +175,7 @@ func TestUpdateExtensions(t *testing.T) {
     <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm">
         <updatecheck status="noupdate">
             <urls>
-                <url codebase="https://brave-core-ext.s3.brave.com/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"></url>
+                <url codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"></url>
             </urls>
             <manifest version="1.0.0">
                 <packages>
@@ -205,7 +205,7 @@ func TestUpdateExtensions(t *testing.T) {
     <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm">
         <updatecheck status="ok">
             <urls>
-                <url codebase="https://brave-core-ext.s3.brave.com/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"></url>
+                <url codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"></url>
             </urls>
             <manifest version="1.0.0">
                 <packages>
@@ -223,7 +223,7 @@ func TestUpdateExtensions(t *testing.T) {
     <app appid="bfdgpgibhagkpdlnjonhkabjoijopoge">
         <updatecheck status="ok">
             <urls>
-                <url codebase="https://brave-core-ext.s3.brave.com/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"></url>
+                <url codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"></url>
             </urls>
             <manifest version="1.0.0">
                 <packages>
@@ -241,7 +241,7 @@ func TestUpdateExtensions(t *testing.T) {
     <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm">
         <updatecheck status="ok">
             <urls>
-                <url codebase="https://brave-core-ext.s3.brave.com/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"></url>
+                <url codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"></url>
             </urls>
             <manifest version="1.0.0">
                 <packages>
@@ -253,7 +253,7 @@ func TestUpdateExtensions(t *testing.T) {
     <app appid="bfdgpgibhagkpdlnjonhkabjoijopoge">
         <updatecheck status="ok">
             <urls>
-                <url codebase="https://brave-core-ext.s3.brave.com/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"></url>
+                <url codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"></url>
             </urls>
             <manifest version="1.0.0">
                 <packages>
@@ -290,7 +290,7 @@ func TestUpdateExtensions(t *testing.T) {
     <app appid="newext1eplbcioakkpcpgfkobkghlhen">
         <updatecheck status="ok">
             <urls>
-                <url codebase="https://brave-core-ext.s3.brave.com/release/newext1eplbcioakkpcpgfkobkghlhen/extension_1_0_0.crx"></url>
+                <url codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/newext1eplbcioakkpcpgfkobkghlhen/extension_1_0_0.crx"></url>
             </urls>
             <manifest version="1.0.0">
                 <packages>
@@ -308,7 +308,7 @@ func TestUpdateExtensions(t *testing.T) {
     <app appid="newext2eplbcioakkpcpgfkobkghlhen">
         <updatecheck status="ok">
             <urls>
-                <url codebase="https://brave-core-ext.s3.brave.com/release/newext2eplbcioakkpcpgfkobkghlhen/extension_1_0_0.crx"></url>
+                <url codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/newext2eplbcioakkpcpgfkobkghlhen/extension_1_0_0.crx"></url>
             </urls>
             <manifest version="1.0.0">
                 <packages>
@@ -344,7 +344,7 @@ func TestWebStoreUpdateExtension(t *testing.T) {
 	query = "?" + getQueryParams(&outdatedLightThemeExtension)
 	expectedResponse = `<gupdate protocol="3.1" server="prod">
     <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm" status="ok">
-        <updatecheck status="ok" codebase="https://brave-core-ext.s3.brave.com/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx" version="1.0.0" hash_sha256="1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618"></updatecheck>
+        <updatecheck status="ok" codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx" version="1.0.0" hash_sha256="1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618"></updatecheck>
     </app>
 </gupdate>`
 	testCall(t, server, http.MethodGet, query, requestBody, http.StatusOK, expectedResponse, "")
@@ -356,10 +356,10 @@ func TestWebStoreUpdateExtension(t *testing.T) {
 	query = "?" + getQueryParams(&outdatedLightThemeExtension) + "&" + getQueryParams(&outdatedDarkThemeExtension)
 	expectedResponse = `<gupdate protocol="3.1" server="prod">
     <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm" status="ok">
-        <updatecheck status="ok" codebase="https://brave-core-ext.s3.brave.com/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx" version="1.0.0" hash_sha256="1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618"></updatecheck>
+        <updatecheck status="ok" codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx" version="1.0.0" hash_sha256="1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618"></updatecheck>
     </app>
     <app appid="bfdgpgibhagkpdlnjonhkabjoijopoge" status="ok">
-        <updatecheck status="ok" codebase="https://brave-core-ext.s3.brave.com/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx" version="1.0.0" hash_sha256="ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834"></updatecheck>
+        <updatecheck status="ok" codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx" version="1.0.0" hash_sha256="ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834"></updatecheck>
     </app>
 </gupdate>`
 	testCall(t, server, http.MethodGet, query, requestBody, http.StatusOK, expectedResponse, "")


### PR DESCRIPTION
## Description

Hardcoding production S3 buckets in the go-updater code causes problems in dev environments. This change uses `S3_EXTENSIONS_BUCKET_HOST` environment variable to check if `go-updater` is running in production or development environment.

Prod `S3_EXTENSIONS_BUCKET_HOST`: `brave-core-ext.s3.brave.com`
Dev `S3_EXTENSIONS_BUCKET_HOST`: `brave-core-ext.s3.bravesoftware.com`

auditors: @bbondy, @hspencer77, @mihaiplesa 

## Test Plan

Automated tests should pass.