### PR TITLE
Issue 20: Updating fallback URL for extensions and removing braveRedirects

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -153,7 +153,7 @@ func WebStoreUpdateExtension(w http.ResponseWriter, r *http.Request) {
 
 		foundExtension, ok := AllExtensionsMap[id]
 		if !ok && len(xValues) == 1 {
-			http.Redirect(w, r, "https://clients2.google.com/service/update2/crx?"+r.URL.RawQuery+"&braveRedirect=true", http.StatusTemporaryRedirect)
+			http.Redirect(w, r, "https://extensionupdater.brave.com/service/update2/crx?"+r.URL.RawQuery, http.StatusTemporaryRedirect)
 			return
 		}
 		if extension.CompareVersions(v, foundExtension.Version) < 0 {
@@ -210,11 +210,11 @@ func UpdateExtensions(w http.ResponseWriter, r *http.Request) {
 	if len(updateRequest) == 1 {
 		_, ok := AllExtensionsMap[updateRequest[0].ID]
 		if !ok {
-			queryString := "braveRedirect=true"
+			queryString := ""
 			if len(r.URL.RawQuery) != 0 {
-				queryString = r.URL.RawQuery + "&" + queryString
+				queryString = "?" + r.URL.RawQuery
 			}
-			http.Redirect(w, r, "https://componentupdater.brave.com/service/update2?"+queryString, http.StatusTemporaryRedirect)
+			http.Redirect(w, r, "https://componentupdater.brave.com/service/update2"+queryString, http.StatusTemporaryRedirect)
 			return
 		}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -268,13 +268,13 @@ func TestUpdateExtensions(t *testing.T) {
 	// Unkonwn extension ID goes to Google server via componentupdater proxy
 	requestBody = extensiontest.ExtensionRequestFnFor("aaaaaaaaaaaaaaaaaaaa")("0.0.0")
 	expectedResponse = ""
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2?braveRedirect=true")
+	testCall(t, server, http.MethodPost, "", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2")
 
 	// Unkonwn extension ID goes to Google server via componentupdater proxy
 	// and preserves query params
 	requestBody = extensiontest.ExtensionRequestFnFor("aaaaaaaaaaaaaaaaaaaa")("0.0.0")
 	expectedResponse = ""
-	testCall(t, server, http.MethodPost, "?test=hi", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2?test=hi&braveRedirect=true")
+	testCall(t, server, http.MethodPost, "?test=hi", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2?test=hi")
 
 	// Make sure a huge request body does not crash the server
 	data := make([]byte, 1024*1024*11) // 11 MiB
@@ -377,8 +377,8 @@ func TestWebStoreUpdateExtension(t *testing.T) {
 		Version: "0.0.0",
 	}
 	query = "?" + getQueryParams(&unknownExtension)
-	expectedResponse = `<a href="https://clients2.google.com/service/update2/crx?x=id%3Daaaaaaaaaaaaaaaaaaaa%26v%3D0.0.0&amp;braveRedirect=true">Temporary Redirect</a>.`
-	testCall(t, server, http.MethodGet, query, requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://clients2.google.com/service/update2/crx?x=id%3Daaaaaaaaaaaaaaaaaaaa%26v%3D0.0.0&braveRedirect=true")
+	expectedResponse = `<a href="https://extensionupdater.brave.com/service/update2/crx?x=id%3Daaaaaaaaaaaaaaaaaaaa%26v%3D0.0.0">Temporary Redirect</a>.`
+	testCall(t, server, http.MethodGet, query, requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://extensionupdater.brave.com/service/update2/crx?x=id%3Daaaaaaaaaaaaaaaaaaaa%26v%3D0.0.0")
 
 	// Unkonwn extension ID with multiple extensions, we try to handle ourselves.
 	unknownExtension = extension.Extension{


### PR DESCRIPTION
fixes: https://github.com/brave/go-update/issues/20

Instead of going into a redirect loop with `braveRedirect`, setting the fallback URL for extensions to `extensionupdater.brave.com` which serves as the proxy for `clients2.google.com`

## Test Plan:

- [x] Default component installs work
- [x] Extension installs work
- [x] Component updates work
- [x] Extension updates work