### PR TITLE
Issue 24: Implement JSON parser for extension and component updates

### DIFF
--- a/extension/extensiontest/extensiontest.go
+++ b/extension/extensiontest/extensiontest.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 )
 
-// ExtensionRequestFnFor creates a function for the specified appID which creates a function
+// ExtensionRequestFnForXML creates a function for the specified appID which creates a function
 // which takes in a version and returns an XML request.
-func ExtensionRequestFnFor(appID string) func(string) string {
+func ExtensionRequestFnForXML(appID string) func(string) string {
 	return func(version string) string {
 		return fmt.Sprintf(`
 		<?xml version="1.0" encoding="UTF-8"?>
@@ -21,9 +21,18 @@ func ExtensionRequestFnFor(appID string) func(string) string {
 	}
 }
 
-// ExtensionRequestFnForTwo creates a function for the specified appIDs which creates a function
+// ExtensionRequestFnForJSON creates a function for the specified appID which creates a function
+// which takes in a version and returns an XML request.
+func ExtensionRequestFnForJSON(appID string) func(string) string {
+	return func(version string) string {
+		return fmt.Sprintf(`{"request":{"protocol":"3.1","version":"chrome-53.0.2785.116","prodversion":"53.0.2785.116","requestid":"{e821bacd-8dbf-4cc8-9e8c-bcbe8c1cfd3d}","lang":"","updaterchannel":"stable","prodchannel":"stable","os":"mac","arch":"x64","nacl_arch":"x86-64","hw":{"physmemory":16},"os":{"arch":"x86_64","platform":"Mac OS X","version":"10.14.3"},"app":[{"appid":"%s","installsource":"ondemand","ping":{"r":-2},"updatecheck":{},"version":"%s"}]}}
+`, appID, version)
+	}
+}
+
+// ExtensionRequestFnForTwoXML creates a function for the specified appIDs which creates a function
 // which takes in the appID versions and returns an XML request.
-func ExtensionRequestFnForTwo(appID1 string, appID2 string) func(string, string) string {
+func ExtensionRequestFnForTwoXML(appID1 string, appID2 string) func(string, string) string {
 	return func(version1 string, version2 string) string {
 		return fmt.Sprintf(`
 		<?xml version="1.0" encoding="UTF-8"?>
@@ -39,5 +48,14 @@ func ExtensionRequestFnForTwo(appID1 string, appID2 string) func(string, string)
 			<ping rd="-2" ping_freshness="" />
 		</app>
 		</request>`, appID1, version1, appID2, version2)
+	}
+}
+
+// ExtensionRequestFnForTwoJSON creates a function for the specified appIDs which creates a function
+// which takes in the appID versions and returns an XML request.
+func ExtensionRequestFnForTwoJSON(appID1 string, appID2 string) func(string, string) string {
+	return func(version1 string, version2 string) string {
+		return fmt.Sprintf(`
+		{"request":{"protocol":"3.1","version":"chrome-53.0.2785.116","prodversion":"53.0.2785.116","requestid":"{e821bacd-8dbf-4cc8-9e8c-bcbe8c1cfd3d}","lang":"","updaterchannel":"stable","prodchannel":"stable","os":"mac","arch":"x64","nacl_arch":"x86-64","hw":{"physmemory":16},"os":{"arch":"x86_64","platform":"Mac OS X","version":"10.14.3"},"app":[{"appid":"%s","installsource":"ondemand","ping":{"r":-2},"updatecheck":{},"version":"%s"},{"appid":"%s","installsource":"ondemand","ping":{"r":-2},"updatecheck":{},"version":"%s"}]}}`, appID1, version1, appID2, version2)
 	}
 }

--- a/extension/json.go
+++ b/extension/json.go
@@ -50,7 +50,7 @@ func (updateResponse *UpdateResponse) MarshalJSON() ([]byte, error) {
 	response.Server = "prod"
 	for _, extension := range *updateResponse {
 		app := App{AppID: extension.ID, Status: "ok"}
-		app.UpdateCheck = UpdateCheck{Status: UpdateStatus(extension)}
+		app.UpdateCheck = UpdateCheck{Status: GetUpdateStatus(extension)}
 		extensionName := "extension_" + strings.Replace(extension.Version, ".", "_", -1) + ".crx"
 		url := "https://" + GetS3ExtensionBucketHost() + "/release/" + extension.ID + "/" + extensionName
 		app.UpdateCheck.URLs.URLs = append(app.UpdateCheck.URLs.URLs, URL{

--- a/extension/json.go
+++ b/extension/json.go
@@ -1,0 +1,156 @@
+package extension
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// MarshalJSON encodes the extension list into response JSON
+func (updateResponse *UpdateResponse) MarshalJSON() ([]byte, error) {
+	type URL struct {
+		Codebase string `json:"codebase"`
+	}
+	type URLs struct {
+		URLs []URL `json:"url"`
+	}
+	type Package struct {
+		Name     string `json:"name"`
+		SHA256   string `json:"hash_sha256"`
+		Required bool   `json:"required"`
+	}
+	type Packages struct {
+		Package []Package `json:"package"`
+	}
+	type Manifest struct {
+		Version  string   `json:"version"`
+		Packages Packages `json:"packages"`
+	}
+	type UpdateCheck struct {
+		Status   string   `json:"status"`
+		URLs     URLs     `json:"urls"`
+		Manifest Manifest `json:"manifest"`
+	}
+	type App struct {
+		AppID       string      `json:"appid"`
+		Status      string      `json:"status"`
+		UpdateCheck UpdateCheck `json:"updatecheck"`
+	}
+	type Response struct {
+		Protocol string `json:"protocol"`
+		Server   string `json:"server"`
+		Apps     []App  `json:"app"`
+	}
+	type JSONResponse struct {
+		Response Response `json:"response"`
+	}
+
+	response := Response{}
+	response.Protocol = "3.1"
+	response.Server = "prod"
+	for _, extension := range *updateResponse {
+		app := App{AppID: extension.ID, Status: "ok"}
+		app.UpdateCheck = UpdateCheck{Status: UpdateStatus(extension)}
+		extensionName := "extension_" + strings.Replace(extension.Version, ".", "_", -1) + ".crx"
+		url := "https://" + GetS3ExtensionBucketHost() + "/release/" + extension.ID + "/" + extensionName
+		app.UpdateCheck.URLs.URLs = append(app.UpdateCheck.URLs.URLs, URL{
+			Codebase: url,
+		})
+		app.UpdateCheck.Manifest = Manifest{
+			Version: extension.Version,
+		}
+		pkg := Package{
+			Name:     extensionName,
+			SHA256:   extension.SHA256,
+			Required: true,
+		}
+		app.UpdateCheck.Manifest.Packages.Package = append(app.UpdateCheck.Manifest.Packages.Package, pkg)
+		response.Apps = append(response.Apps, app)
+	}
+
+	jsonResponse := JSONResponse{}
+	jsonResponse.Response = response
+	return json.Marshal(jsonResponse)
+}
+
+// MarshalJSON encodes the extension list into response JSON
+func (updateResponse *WebStoreUpdateResponse) MarshalJSON() ([]byte, error) {
+	type UpdateCheck struct {
+		Status   string `json:"status"`
+		Codebase string `json:"codebase"`
+		Version  string `json:"version"`
+		SHA256   string `json:"hash_sha256"`
+	}
+	type App struct {
+		AppID       string      `json:"appid"`
+		Status      string      `json:"status"`
+		UpdateCheck UpdateCheck `json:"updatecheck"`
+	}
+	type GUpdate struct {
+		Protocol string `json:"protocol"`
+		Server   string `json:"server"`
+		Apps     []App  `json:"app"`
+	}
+	type JSONGUpdate struct {
+		GUpdate GUpdate `json:"gupdate"`
+	}
+	response := GUpdate{}
+	response.Protocol = "3.1"
+	response.Server = "prod"
+
+	for _, extension := range *updateResponse {
+		extensionName := "extension_" + strings.Replace(extension.Version, ".", "_", -1) + ".crx"
+		app := App{
+			AppID:  extension.ID,
+			Status: "ok",
+			UpdateCheck: UpdateCheck{
+				Status:   "ok",
+				SHA256:   extension.SHA256,
+				Version:  extension.Version,
+				Codebase: "https://" + GetS3ExtensionBucketHost() + "/release/" + extension.ID + "/" + extensionName,
+			},
+		}
+		response.Apps = append(response.Apps, app)
+	}
+	jsonGupdate := JSONGUpdate{}
+	jsonGupdate.GUpdate = response
+
+	return json.Marshal(jsonGupdate)
+}
+
+// UnmarshalJSON decodes the update server request JSON data for a list of extensions
+func (updateRequest *UpdateRequest) UnmarshalJSON(b []byte) error {
+	type App struct {
+		AppID   string `json:"appid"`
+		Version string `json:"version"`
+	}
+	type Request struct {
+		OS       string `json:"@os"`
+		Updater  string `json:"@updater"`
+		App      []App  `json:"app"`
+		Protocol string `json:"protocol"`
+	}
+	type JSONRequest struct {
+		Request Request `json:"request"`
+	}
+
+	request := JSONRequest{}
+	err := json.Unmarshal(b, &request)
+	if err != nil {
+		return err
+	}
+
+	*updateRequest = UpdateRequest{}
+	for _, app := range request.Request.App {
+		*updateRequest = append(*updateRequest, Extension{
+			ID:      app.AppID,
+			Version: app.Version,
+		})
+	}
+
+	if request.Request.Protocol != "3.0" && request.Request.Protocol != "3.1" {
+		err = fmt.Errorf("request version: %v not supported", request.Request.Protocol)
+	}
+
+	return err
+}

--- a/extension/json_test.go
+++ b/extension/json_test.go
@@ -1,0 +1,118 @@
+package extension
+
+import (
+	"encoding/json"
+	"github.com/brave/go-update/extension/extensiontest"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestUpdateResponseMarshalJSON(t *testing.T) {
+	allExtensionsMap := LoadExtensionsIntoMap(&OfferedExtensions)
+	// Empty extension list returns a blank JSON update
+	updateResponse := UpdateResponse{}
+	jsonData, err := json.Marshal(&updateResponse)
+	assert.Nil(t, err)
+	expectedOutput := `{"response":{"protocol":"3.1","server":"prod","app":null}}`
+	assert.Equal(t, expectedOutput, string(jsonData))
+
+	darkThemeExtension, ok := allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	assert.True(t, ok)
+
+	// Single extension list returns a single JSON update
+	updateResponse = []Extension{darkThemeExtension}
+	jsonData, err = json.Marshal(&updateResponse)
+	assert.Nil(t, err)
+	expectedOutput = `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","hash_sha256":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834","required":true}]}}}}]}}`
+	assert.Equal(t, expectedOutput, string(jsonData))
+
+	// Multiple extensions returns a multiple extension JSON update
+	lightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
+	assert.True(t, ok)
+	darkThemeExtension, ok = allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	assert.True(t, ok)
+	updateResponse = []Extension{lightThemeExtension, darkThemeExtension}
+	jsonData, err = json.Marshal(&updateResponse)
+	assert.Nil(t, err)
+	expectedOutput = `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","hash_sha256":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","required":true}]}}}},{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","hash_sha256":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834","required":true}]}}}}]}}`
+	assert.Equal(t, expectedOutput, string(jsonData))
+}
+
+func TestUpdateRequestUnmarshalJSON(t *testing.T) {
+	// Empty data returns an error
+	updateRequest := UpdateRequest{}
+	err := json.Unmarshal([]byte(""), &updateRequest)
+	assert.NotNil(t, err, "UnmarshalJSON should return an error for empty content")
+
+	// Malformed JSON returns an error
+	err = json.Unmarshal([]byte("{"), &updateRequest)
+	assert.NotNil(t, err, "UnmarshalJSON should return an error for malformed JSON")
+
+	// Wrong schema returns an error
+	err = json.Unmarshal([]byte(`{"response":"hello world!"}`), &updateRequest)
+	assert.NotNil(t, err, "UnmarshalJSON should return an error for wrong JSON Schema")
+
+	// No extensions JSON with proper schema, no error with 0 extensions returned
+	data := []byte(`{"request":{"protocol":"3.1","version":"chrome-53.0.2785.116","prodversion":"53.0.2785.116","requestid":"{e821bacd-8dbf-4cc8-9e8c-bcbe8c1cfd3d}","lang":"","updaterchannel":"stable","prodchannel":"stable","os":"mac","arch":"x64","nacl_arch":"x86-64","hw":{"physmemory":16},"os":{"arch":"x86_64","platform":"Mac OS X","version":"10.14.3"}}}`)
+	err = json.Unmarshal(data, &updateRequest)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(updateRequest))
+
+	onePasswordID := "aomjjhallfgjeglblehebfpbcfeobpgk" // #nosec
+	onePasswordVersion := "4.7.0.90"
+	onePasswordRequest := extensiontest.ExtensionRequestFnForJSON(onePasswordID)
+	data = []byte(onePasswordRequest(onePasswordVersion))
+	err = json.Unmarshal(data, &updateRequest)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(updateRequest))
+	assert.Equal(t, onePasswordID, updateRequest[0].ID)
+	assert.Equal(t, onePasswordVersion, updateRequest[0].Version)
+
+	pdfJSID := "jdbefljfgobbmcidnmpjamcbhnbphjnb"
+	pdfJSVersion := "1.0.0"
+	twoExtensionRequest := extensiontest.ExtensionRequestFnForTwoJSON(onePasswordID, pdfJSID)
+	data = []byte(twoExtensionRequest(onePasswordVersion, pdfJSVersion))
+	err = json.Unmarshal(data, &updateRequest)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(updateRequest))
+	assert.Equal(t, onePasswordID, updateRequest[0].ID)
+	assert.Equal(t, onePasswordVersion, updateRequest[0].Version)
+	assert.Equal(t, pdfJSID, updateRequest[1].ID)
+	assert.Equal(t, pdfJSVersion, updateRequest[1].Version)
+
+	// Check for unsupported protocol version
+	data = []byte(`{"request":{"protocol":"2","version":"chrome-53.0.2785.116","prodversion":"53.0.2785.116","requestid":"{e821bacd-8dbf-4cc8-9e8c-bcbe8c1cfd3d}","lang":"","updaterchannel":"stable","prodchannel":"stable","os":"mac","arch":"x64","nacl_arch":"x86-64","hw":{"physmemory":16},"os":{"arch":"x86_64","platform":"Mac OS X","version":"10.14.3"}}}`)
+	err = json.Unmarshal(data, &updateRequest)
+	assert.NotNil(t, err, "Unrecognized protocol should have an error")
+}
+
+func TestWebStoreUpdateResponseMarshalJSON(t *testing.T) {
+	// No extensions returns blank update response
+	updateResponse := WebStoreUpdateResponse{}
+	allExtensionsMap := LoadExtensionsIntoMap(&OfferedExtensions)
+	jsonData, err := json.Marshal(&updateResponse)
+	assert.Nil(t, err)
+	expectedOutput := `{"gupdate":{"protocol":"3.1","server":"prod","app":null}}`
+	assert.Equal(t, expectedOutput, string(jsonData))
+
+	darkThemeExtension, ok := allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	assert.True(t, ok)
+
+	// Single extension list returns a single JSON update
+	updateResponse = WebStoreUpdateResponse{darkThemeExtension}
+	jsonData, err = json.Marshal(&updateResponse)
+	assert.Nil(t, err)
+	expectedOutput = `{"gupdate":{"protocol":"3.1","server":"prod","app":[{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"ok","codebase":"https://` + GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx","version":"1.0.0","hash_sha256":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834"}}]}}`
+	assert.Equal(t, expectedOutput, string(jsonData))
+
+	// Multiple extensions returns a multiple extension JSON webstore update
+	lightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
+	assert.True(t, ok)
+	darkThemeExtension, ok = allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	assert.True(t, ok)
+	updateResponse = WebStoreUpdateResponse{lightThemeExtension, darkThemeExtension}
+	jsonData, err = json.Marshal(&updateResponse)
+	assert.Nil(t, err)
+	expectedOutput = `{"gupdate":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"ok","codebase":"https://` + GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx","version":"1.0.0","hash_sha256":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618"}},{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"ok","codebase":"https://` + GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx","version":"1.0.0","hash_sha256":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834"}}]}}`
+	assert.Equal(t, expectedOutput, string(jsonData))
+}

--- a/extension/utils.go
+++ b/extension/utils.go
@@ -1,0 +1,22 @@
+package extension
+
+import (
+	"os"
+)
+
+// GetS3ExtensionBucketHost returns the bucket to use for accessing the crx files
+func GetS3ExtensionBucketHost() string {
+	s3BucketHost, ok := os.LookupEnv("S3_EXTENSIONS_BUCKET_HOST")
+	if !ok {
+		s3BucketHost = "brave-core-ext.s3.brave.com"
+	}
+	return s3BucketHost
+}
+
+// UpdateStatus returns the status of an update response for an extension
+func UpdateStatus(extension Extension) string {
+	if extension.Status == "" {
+		return "ok"
+	}
+	return extension.Status
+}

--- a/extension/utils.go
+++ b/extension/utils.go
@@ -13,8 +13,8 @@ func GetS3ExtensionBucketHost() string {
 	return s3BucketHost
 }
 
-// UpdateStatus returns the status of an update response for an extension
-func UpdateStatus(extension Extension) string {
+// GetUpdateStatus returns the status of an update response for an extension
+func GetUpdateStatus(extension Extension) string {
 	if extension.Status == "" {
 		return "ok"
 	}

--- a/extension/xml.go
+++ b/extension/xml.go
@@ -3,26 +3,8 @@ package extension
 import (
 	"encoding/xml"
 	"fmt"
-	"os"
 	"strings"
 )
-
-// GetS3ExtensionBucketHost returns the bucket to use for accessing the crx files
-func GetS3ExtensionBucketHost() string {
-	s3BucketHost, ok := os.LookupEnv("S3_EXTENSIONS_BUCKET_HOST")
-	if !ok {
-		s3BucketHost = "brave-core-ext.s3.brave.com"
-	}
-	return s3BucketHost
-}
-
-// UpdateStatus returns the status of an update response for an extension
-func UpdateStatus(extension Extension) string {
-	if extension.Status == "" {
-		return "ok"
-	}
-	return extension.Status
-}
 
 // MarshalXML encodes the extension list into response XML
 func (updateResponse *UpdateResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {

--- a/extension/xml.go
+++ b/extension/xml.go
@@ -53,7 +53,7 @@ func (updateResponse *UpdateResponse) MarshalXML(e *xml.Encoder, start xml.Start
 	response.Server = "prod"
 	for _, extension := range *updateResponse {
 		app := App{AppID: extension.ID}
-		app.UpdateCheck = UpdateCheck{Status: UpdateStatus(extension)}
+		app.UpdateCheck = UpdateCheck{Status: GetUpdateStatus(extension)}
 		extensionName := "extension_" + strings.Replace(extension.Version, ".", "_", -1) + ".crx"
 		url := "https://" + GetS3ExtensionBucketHost() + "/release/" + extension.ID + "/" + extensionName
 		app.UpdateCheck.URLs.URLs = append(app.UpdateCheck.URLs.URLs, URL{

--- a/extension/xml_test.go
+++ b/extension/xml_test.go
@@ -102,7 +102,7 @@ func TestUpdateRequestUnmarshalXML(t *testing.T) {
 
 	onePasswordID := "aomjjhallfgjeglblehebfpbcfeobpgk" // #nosec
 	onePasswordVersion := "4.7.0.90"
-	onePasswordRequest := extensiontest.ExtensionRequestFnFor(onePasswordID)
+	onePasswordRequest := extensiontest.ExtensionRequestFnForXML(onePasswordID)
 	data = []byte(onePasswordRequest(onePasswordVersion))
 	err = xml.Unmarshal(data, &updateRequest)
 	assert.Nil(t, err)
@@ -112,7 +112,7 @@ func TestUpdateRequestUnmarshalXML(t *testing.T) {
 
 	pdfJSID := "jdbefljfgobbmcidnmpjamcbhnbphjnb"
 	pdfJSVersion := "1.0.0"
-	twoExtensionRequest := extensiontest.ExtensionRequestFnForTwo(onePasswordID, pdfJSID)
+	twoExtensionRequest := extensiontest.ExtensionRequestFnForTwoXML(onePasswordID, pdfJSID)
 	data = []byte(twoExtensionRequest(onePasswordVersion, pdfJSVersion))
 	err = xml.Unmarshal(data, &updateRequest)
 	assert.Nil(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -22,6 +22,9 @@ var newExtension1 = extension.Extension{}
 var newExtension2 = extension.Extension{}
 var handler http.Handler
 
+var contentTypeXML = "application/xml"
+var contentTypeJSON = "application/json"
+
 func init() {
 	newExtensionID1 := "newext1eplbcioakkpcpgfkobkghlhen"
 	newExtension1 = extension.Extension{
@@ -74,12 +77,12 @@ func TestPing(t *testing.T) {
 	}
 }
 
-func testCall(t *testing.T, server *httptest.Server, method string, query string,
+func testCall(t *testing.T, server *httptest.Server, method string, contentType string, query string,
 	requestBody string, expectedResponseCode int, expectedResponse string, redirectLocation string) {
 	extensionsURL := fmt.Sprintf("%s/extensions%s", server.URL, query)
 	req, err := http.NewRequest(method, extensionsURL, bytes.NewBuffer([]byte(requestBody)))
 	assert.Nil(t, err)
-	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Content-Type", contentType)
 
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -104,7 +107,7 @@ func testCall(t *testing.T, server *httptest.Server, method string, query string
 	assert.Equal(t, expectedResponse, strings.TrimSpace(string(actual)))
 }
 
-func TestUpdateExtensions(t *testing.T) {
+func TestUpdateExtensionsXML(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -116,7 +119,7 @@ func TestUpdateExtensions(t *testing.T) {
 		  <os platform="Mac OS X" version="10.11.6" arch="x86_64"/>
 		</request>`
 	expectedResponse := "<response protocol=\"3.1\" server=\"prod\"></response>"
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Unsupported protocol version
 	requestBody =
@@ -127,29 +130,29 @@ func TestUpdateExtensions(t *testing.T) {
 			</app>
 		</request>`
 	expectedResponse = "Error reading body request version: 2.0 not supported"
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusBadRequest, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusBadRequest, expectedResponse, "")
 
 	// Not XML
 	requestBody = "For the king!"
 	expectedResponse = "Error reading body EOF"
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusBadRequest, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusBadRequest, expectedResponse, "")
 
 	// Malformed XML
 	requestBody = "<This way! No, that way!"
 	expectedResponse = "Error reading body XML syntax error on line 1: attribute name without = in element"
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusBadRequest, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusBadRequest, expectedResponse, "")
 
 	// Different XML schema
 	requestBody = "<text>For the alliance!</text>"
 	expectedResponse = "Error reading body expected element type <request> but have <text>"
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusBadRequest, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusBadRequest, expectedResponse, "")
 
 	// Empty body request
 	requestBody = ""
 	expectedResponse = "Error reading body EOF"
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusBadRequest, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusBadRequest, expectedResponse, "")
 
-	lightThemeExtension := extensiontest.ExtensionRequestFnFor("ldimlcelhnjgpjjemdjokpgeeikdinbm")
+	lightThemeExtension := extensiontest.ExtensionRequestFnForXML("ldimlcelhnjgpjjemdjokpgeeikdinbm")
 
 	// Single extension out of date
 	requestBody = lightThemeExtension("0.0.0")
@@ -167,7 +170,7 @@ func TestUpdateExtensions(t *testing.T) {
         </updatecheck>
     </app>
 </response>`
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Single extension same version
 	requestBody = lightThemeExtension("1.0.0")
@@ -185,19 +188,19 @@ func TestUpdateExtensions(t *testing.T) {
         </updatecheck>
     </app>
 </response>`
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Single extension greater version
 	requestBody = lightThemeExtension("2.0.0")
 	expectedResponse = "<response protocol=\"3.1\" server=\"prod\"></response>"
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 
-	lightAndDarkThemeRequest := extensiontest.ExtensionRequestFnForTwo("ldimlcelhnjgpjjemdjokpgeeikdinbm", "bfdgpgibhagkpdlnjonhkabjoijopoge")
+	lightAndDarkThemeRequest := extensiontest.ExtensionRequestFnForTwoXML("ldimlcelhnjgpjjemdjokpgeeikdinbm", "bfdgpgibhagkpdlnjonhkabjoijopoge")
 
 	// Multiple components with none out of date
 	requestBody = lightAndDarkThemeRequest("70.0.0", "70.0.0")
 	expectedResponse = "<response protocol=\"3.1\" server=\"prod\"></response>"
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Only one components out of date
 	requestBody = lightAndDarkThemeRequest("0.0.0", "70.0.0")
@@ -215,7 +218,7 @@ func TestUpdateExtensions(t *testing.T) {
         </updatecheck>
     </app>
 </response>`
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Other component of 2 out of date
 	requestBody = lightAndDarkThemeRequest("70.0.0", "0.0.0")
@@ -233,7 +236,7 @@ func TestUpdateExtensions(t *testing.T) {
         </updatecheck>
     </app>
 </response>`
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Both components need updates
 	requestBody = lightAndDarkThemeRequest("0.0.0", "0.0.0")
@@ -263,18 +266,18 @@ func TestUpdateExtensions(t *testing.T) {
         </updatecheck>
     </app>
 </response>`
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Unkonwn extension ID goes to Google server via componentupdater proxy
-	requestBody = extensiontest.ExtensionRequestFnFor("aaaaaaaaaaaaaaaaaaaa")("0.0.0")
+	requestBody = extensiontest.ExtensionRequestFnForXML("aaaaaaaaaaaaaaaaaaaa")("0.0.0")
 	expectedResponse = ""
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2")
 
 	// Unkonwn extension ID goes to Google server via componentupdater proxy
 	// and preserves query params
-	requestBody = extensiontest.ExtensionRequestFnFor("aaaaaaaaaaaaaaaaaaaa")("0.0.0")
+	requestBody = extensiontest.ExtensionRequestFnForXML("aaaaaaaaaaaaaaaaaaaa")("0.0.0")
 	expectedResponse = ""
-	testCall(t, server, http.MethodPost, "?test=hi", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2?test=hi")
+	testCall(t, server, http.MethodPost, contentTypeXML, "?test=hi", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2?test=hi")
 
 	// Make sure a huge request body does not crash the server
 	data := make([]byte, 1024*1024*11) // 11 MiB
@@ -282,10 +285,10 @@ func TestUpdateExtensions(t *testing.T) {
 	assert.Nil(t, err)
 	requestBody = string(data)
 	expectedResponse = "Request too large"
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusBadRequest, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusBadRequest, expectedResponse, "")
 
 	// Single new extension out of date that was added in by the refresh timer
-	requestBody = extensiontest.ExtensionRequestFnFor("newext1eplbcioakkpcpgfkobkghlhen")("0.0.0")
+	requestBody = extensiontest.ExtensionRequestFnForXML("newext1eplbcioakkpcpgfkobkghlhen")("0.0.0")
 	expectedResponse = `<response protocol="3.1" server="prod">
     <app appid="newext1eplbcioakkpcpgfkobkghlhen">
         <updatecheck status="ok">
@@ -300,10 +303,10 @@ func TestUpdateExtensions(t *testing.T) {
         </updatecheck>
     </app>
 </response>`
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Single second new extension out of date that was added in by the refresh timer
-	requestBody = extensiontest.ExtensionRequestFnFor("newext2eplbcioakkpcpgfkobkghlhen")("0.0.0")
+	requestBody = extensiontest.ExtensionRequestFnForXML("newext2eplbcioakkpcpgfkobkghlhen")("0.0.0")
 	expectedResponse = `<response protocol="3.1" server="prod">
     <app appid="newext2eplbcioakkpcpgfkobkghlhen">
         <updatecheck status="ok">
@@ -318,14 +321,14 @@ func TestUpdateExtensions(t *testing.T) {
         </updatecheck>
     </app>
 </response>`
-	testCall(t, server, http.MethodPost, "", requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 }
 
 func getQueryParams(extension *extension.Extension) string {
 	return `x=id%3D` + extension.ID + `%26v%3D` + extension.Version
 }
 
-func TestWebStoreUpdateExtension(t *testing.T) {
+func TestWebStoreUpdateExtensionXML(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -335,7 +338,7 @@ func TestWebStoreUpdateExtension(t *testing.T) {
 	requestBody := ""
 	query := ""
 	expectedResponse := `<gupdate protocol="3.1" server="prod"></gupdate>`
-	testCall(t, server, http.MethodGet, query, requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodGet, contentTypeXML, query, requestBody, http.StatusOK, expectedResponse, "")
 
 	// Extension that we handle which is outdated should produce a response
 	outdatedLightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
@@ -347,7 +350,7 @@ func TestWebStoreUpdateExtension(t *testing.T) {
         <updatecheck status="ok" codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx" version="1.0.0" hash_sha256="1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618"></updatecheck>
     </app>
 </gupdate>`
-	testCall(t, server, http.MethodGet, query, requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodGet, contentTypeXML, query, requestBody, http.StatusOK, expectedResponse, "")
 
 	// Multiple extensions that we handle which are outdated should produce a response
 	outdatedDarkThemeExtension, ok := allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
@@ -362,14 +365,14 @@ func TestWebStoreUpdateExtension(t *testing.T) {
         <updatecheck status="ok" codebase="https://` + extension.GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx" version="1.0.0" hash_sha256="ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834"></updatecheck>
     </app>
 </gupdate>`
-	testCall(t, server, http.MethodGet, query, requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodGet, contentTypeXML, query, requestBody, http.StatusOK, expectedResponse, "")
 
 	// Extension that we handle which is up to date should NOT produce an update but still be successful
 	lightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
 	assert.True(t, ok)
 	query = "?" + getQueryParams(&lightThemeExtension)
 	expectedResponse = `<gupdate protocol="3.1" server="prod"></gupdate>`
-	testCall(t, server, http.MethodGet, query, requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodGet, contentTypeXML, query, requestBody, http.StatusOK, expectedResponse, "")
 
 	// Unkonwn extension ID goes to Google server
 	unknownExtension := extension.Extension{
@@ -378,7 +381,7 @@ func TestWebStoreUpdateExtension(t *testing.T) {
 	}
 	query = "?" + getQueryParams(&unknownExtension)
 	expectedResponse = `<a href="https://extensionupdater.brave.com/service/update2/crx?x=id%3Daaaaaaaaaaaaaaaaaaaa%26v%3D0.0.0">Temporary Redirect</a>.`
-	testCall(t, server, http.MethodGet, query, requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://extensionupdater.brave.com/service/update2/crx?x=id%3Daaaaaaaaaaaaaaaaaaaa%26v%3D0.0.0")
+	testCall(t, server, http.MethodGet, contentTypeXML, query, requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://extensionupdater.brave.com/service/update2/crx?x=id%3Daaaaaaaaaaaaaaaaaaaa%26v%3D0.0.0")
 
 	// Unkonwn extension ID with multiple extensions, we try to handle ourselves.
 	unknownExtension = extension.Extension{
@@ -391,7 +394,159 @@ func TestWebStoreUpdateExtension(t *testing.T) {
 	}
 	query = "?" + getQueryParams(&unknownExtension) + "&" + getQueryParams(&unknownExtension2)
 	expectedResponse = `<gupdate protocol="3.1" server="prod"></gupdate>`
-	testCall(t, server, http.MethodGet, query, requestBody, http.StatusOK, expectedResponse, "")
+	testCall(t, server, http.MethodGet, contentTypeXML, query, requestBody, http.StatusOK, expectedResponse, "")
+}
+
+func TestUpdateExtensionsJSON(t *testing.T) {
+	jsonPrefix := ")]}'\n"
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// No extensions
+	requestBody := `{"request":{"protocol":"3.1","version":"chrome-53.0.2785.116","prodversion":"53.0.2785.116","requestid":"{e821bacd-8dbf-4cc8-9e8c-bcbe8c1cfd3d}","lang":"","updaterchannel":"stable","prodchannel":"stable","os":"mac","arch":"x64","nacl_arch":"x86-64","hw":{"physmemory":16},"os":{"arch":"x86_64","platform":"Mac OS X","version":"10.14.3"}}}`
+	expectedResponse := jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":null}}`
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
+
+	// Unsupported protocol version
+	requestBody = `{"request":{"protocol":"2.0","version":"chrome-53.0.2785.116","prodversion":"53.0.2785.116","requestid":"{e821bacd-8dbf-4cc8-9e8c-bcbe8c1cfd3d}","lang":"","updaterchannel":"stable","prodchannel":"stable","os":"mac","arch":"x64","nacl_arch":"x86-64","hw":{"physmemory":16},"os":{"arch":"x86_64","platform":"Mac OS X","version":"10.14.3"}}}`
+	expectedResponse = "Error reading body request version: 2.0 not supported"
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusBadRequest, expectedResponse, "")
+
+	// Not JSON
+	requestBody = "For the king!"
+	expectedResponse = "Error reading body invalid character 'F' looking for beginning of value"
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusBadRequest, expectedResponse, "")
+
+	// Malformed JSON
+	requestBody = "{request"
+	expectedResponse = "Error reading body invalid character 'r' looking for beginning of object key string"
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusBadRequest, expectedResponse, "")
+
+	lightThemeExtension := extensiontest.ExtensionRequestFnForJSON("ldimlcelhnjgpjjemdjokpgeeikdinbm")
+
+	// Single extension out of date
+	requestBody = lightThemeExtension("0.0.0")
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","hash_sha256":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","required":true}]}}}}]}}`
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
+
+	// Single extension same version
+	requestBody = lightThemeExtension("1.0.0")
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"noupdate","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","hash_sha256":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","required":true}]}}}}]}}`
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
+
+	// Single extension greater version
+	requestBody = lightThemeExtension("2.0.0")
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":null}}`
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
+
+	lightAndDarkThemeRequest := extensiontest.ExtensionRequestFnForTwoJSON("ldimlcelhnjgpjjemdjokpgeeikdinbm", "bfdgpgibhagkpdlnjonhkabjoijopoge")
+
+	// Multiple components with none out of date
+	requestBody = lightAndDarkThemeRequest("70.0.0", "70.0.0")
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":null}}`
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
+
+	// Only one components out of date
+	requestBody = lightAndDarkThemeRequest("0.0.0", "70.0.0")
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","hash_sha256":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","required":true}]}}}}]}}`
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
+
+	// Other component of 2 out of date
+	requestBody = lightAndDarkThemeRequest("70.0.0", "0.0.0")
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","hash_sha256":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834","required":true}]}}}}]}}`
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
+
+	// Both components need updates
+	requestBody = lightAndDarkThemeRequest("0.0.0", "0.0.0")
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","hash_sha256":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","required":true}]}}}},{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","hash_sha256":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834","required":true}]}}}}]}}`
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
+
+	// Unkonwn extension ID goes to Google server via componentupdater proxy
+	requestBody = extensiontest.ExtensionRequestFnForJSON("aaaaaaaaaaaaaaaaaaaa")("0.0.0")
+	expectedResponse = ""
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2/json")
+
+	// Unkonwn extension ID goes to Google server via componentupdater proxy
+	// and preserves query params
+	requestBody = extensiontest.ExtensionRequestFnForJSON("aaaaaaaaaaaaaaaaaaaa")("0.0.0")
+	expectedResponse = ""
+	testCall(t, server, http.MethodPost, contentTypeJSON, "?test=hi", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2/json?test=hi")
+
+	// Make sure a huge request body does not crash the server
+	data := make([]byte, 1024*1024*11) // 11 MiB
+	_, err := rand.Read(data)
+	assert.Nil(t, err)
+	requestBody = string(data)
+	expectedResponse = "Request too large"
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusBadRequest, expectedResponse, "")
+
+	// Single new extension out of date that was added in by the refresh timer
+	requestBody = extensiontest.ExtensionRequestFnForJSON("newext1eplbcioakkpcpgfkobkghlhen")("0.0.0")
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"newext1eplbcioakkpcpgfkobkghlhen","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost() + `/release/newext1eplbcioakkpcpgfkobkghlhen/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","hash_sha256":"4c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","required":true}]}}}}]}}`
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
+
+	// Single second new extension out of date that was added in by the refresh timer
+	requestBody = extensiontest.ExtensionRequestFnForJSON("newext2eplbcioakkpcpgfkobkghlhen")("0.0.0")
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"newext2eplbcioakkpcpgfkobkghlhen","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost() + `/release/newext2eplbcioakkpcpgfkobkghlhen/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","hash_sha256":"3c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","required":true}]}}}}]}}`
+	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
+}
+
+func TestWebStoreUpdateExtensionJSON(t *testing.T) {
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	allExtensionsMap := extension.LoadExtensionsIntoMap(&extension.OfferedExtensions)
+
+	// Empty query param request, no extensions.
+	requestBody := ""
+	query := ""
+	expectedResponse := `{"gupdate":{"protocol":"3.1","server":"prod","app":null}}`
+	testCall(t, server, http.MethodGet, contentTypeJSON, query, requestBody, http.StatusOK, expectedResponse, "")
+
+	// Extension that we handle which is outdated should produce a response
+	outdatedLightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
+	outdatedLightThemeExtension.Version = "0.0.0"
+	assert.True(t, ok)
+	query = "?" + getQueryParams(&outdatedLightThemeExtension)
+	expectedResponse = `{"gupdate":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"ok","codebase":"https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx","version":"1.0.0","hash_sha256":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618"}}]}}`
+	testCall(t, server, http.MethodGet, contentTypeJSON, query, requestBody, http.StatusOK, expectedResponse, "")
+
+	// Multiple extensions that we handle which are outdated should produce a response
+	outdatedDarkThemeExtension, ok := allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	assert.True(t, ok)
+	outdatedDarkThemeExtension.Version = "0.0.0"
+	query = "?" + getQueryParams(&outdatedLightThemeExtension) + "&" + getQueryParams(&outdatedDarkThemeExtension)
+	expectedResponse = `{"gupdate":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"ok","codebase":"https://` + extension.GetS3ExtensionBucketHost() + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx","version":"1.0.0","hash_sha256":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618"}},{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"ok","codebase":"https://` + extension.GetS3ExtensionBucketHost() + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx","version":"1.0.0","hash_sha256":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834"}}]}}`
+	testCall(t, server, http.MethodGet, contentTypeJSON, query, requestBody, http.StatusOK, expectedResponse, "")
+
+	// Extension that we handle which is up to date should NOT produce an update but still be successful
+	lightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
+	assert.True(t, ok)
+	query = "?" + getQueryParams(&lightThemeExtension)
+	expectedResponse = `{"gupdate":{"protocol":"3.1","server":"prod","app":null}}`
+	testCall(t, server, http.MethodGet, contentTypeJSON, query, requestBody, http.StatusOK, expectedResponse, "")
+
+	// Unkonwn extension ID goes to Google server
+	unknownExtension := extension.Extension{
+		ID:      "aaaaaaaaaaaaaaaaaaaa",
+		Version: "0.0.0",
+	}
+	query = "?" + getQueryParams(&unknownExtension)
+	expectedResponse = "<a href=\"https://extensionupdater.brave.com/service/update2/crx?x=id%3Daaaaaaaaaaaaaaaaaaaa%26v%3D0.0.0\">Temporary Redirect</a>."
+	testCall(t, server, http.MethodGet, contentTypeJSON, query, requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://extensionupdater.brave.com/service/update2/crx?x=id%3Daaaaaaaaaaaaaaaaaaaa%26v%3D0.0.0")
+
+	// Unkonwn extension ID with multiple extensions, we try to handle ourselves.
+	unknownExtension = extension.Extension{
+		ID:      "aaaaaaaaaaaaaaaaaaaa",
+		Version: "0.0.0",
+	}
+	unknownExtension2 := extension.Extension{
+		ID:      "bbaaaaaaaaaaaaaaaaaa",
+		Version: "0.0.0",
+	}
+	query = "?" + getQueryParams(&unknownExtension) + "&" + getQueryParams(&unknownExtension2)
+	expectedResponse = `{"gupdate":{"protocol":"3.1","server":"prod","app":null}}`
+	testCall(t, server, http.MethodGet, contentTypeJSON, query, requestBody, http.StatusOK, expectedResponse, "")
 }
 
 func TestPrintExtensions(t *testing.T) {


### PR DESCRIPTION
Fix https://github.com/brave/go-update/issues/24

## Description
Chromium has decided to finally deprecate the `ProtocolHandlerFactoryXML` in C75. We need to support both XML and JSON parsers till C75 reaches stable. 

For `WebStoreUpdateExtension` - We use the `prodversion` query parameter to verify if the request was for C75 or older version to determine which parser to use

For `UpdateExtension` - We use `json.Unmarshal ` to check if the body is a json request or not.

## Test Cases:

Detailed test plan here - https://docs.google.com/document/d/1XIlEJ-rudud5GVqwiUbOcwblJsUxJPbbJehlNpwGdqs/edit