### PR TITLE
Fix 35: Moving lint out of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,11 @@ ENV DEP_SHA256SUM 287b08291e14f1fae8ba44374b26a2b12eb941af3497ed0ca649253e21ba2f
 RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v$DEP_VERSION/dep-linux-amd64
 RUN echo "$DEP_SHA256SUM  /usr/local/bin/dep" | shasum -a 256 -c
 RUN chmod +x /usr/local/bin/dep
-RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-
 
 FROM golang:1.10 as builder
 WORKDIR /go/src/app
 
 COPY --from=dep /usr/local/bin/dep /usr/local/bin/dep
-COPY --from=dep /go/bin/golangci-lint /bin/golangci-lint
 COPY . .
 RUN dep ensure
 RUN /usr/bin/make build


### PR DESCRIPTION
Fix https://github.com/brave/go-update/issues/35

## Description

`golangci-lint` is not required in the Dockerfile since lint is not triggered on build. 