### PR TITLE
Fix 45: Do not proxy requests for Widevine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64
   -o $GOPATH/bin/dep
 - chmod +x $GOPATH/bin/dep
-- go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+- GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
 install:
 - dep ensure
 before_script:

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -24,6 +24,10 @@ import (
 // PDF viewer extension install from chrome web store to the extension updater proxy
 var PDFJSExtensionID = "oemmndcbldboiebfnladdacbdfmadadm"
 
+// WidivineExtensionID is used to add an exception to pass the request for widivine
+// directly to google servers
+var WidivineExtensionID = "oimompecagnajdejgnnjijobebaeigek"
+
 // AllExtensionsMap holds a mapping of extension ID to extension object.
 // This list for tests is populated by extensions.OfferedExtensions.
 // For normal operaitons of this server it is obtained from the AWS config
@@ -248,10 +252,14 @@ func UpdateExtensions(w http.ResponseWriter, r *http.Request) {
 			if len(r.URL.RawQuery) != 0 {
 				queryString = "?" + r.URL.RawQuery
 			}
+			host := "componentupdater.brave.com"
+			if updateRequest[0].ID == WidivineExtensionID {
+				host = "update.googleapis.com"
+			}
 			if jsonRequest {
-				http.Redirect(w, r, "https://componentupdater.brave.com/service/update2/json"+queryString, http.StatusTemporaryRedirect)
+				http.Redirect(w, r, "https://"+host+"/service/update2/json"+queryString, http.StatusTemporaryRedirect)
 			} else {
-				http.Redirect(w, r, "https://componentupdater.brave.com/service/update2"+queryString, http.StatusTemporaryRedirect)
+				http.Redirect(w, r, "https://"+host+"/service/update2"+queryString, http.StatusTemporaryRedirect)
 			}
 			return
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -284,6 +284,11 @@ func TestUpdateExtensionsXML(t *testing.T) {
 	expectedResponse = ""
 	testCall(t, server, http.MethodPost, contentTypeXML, "?test=hi", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://componentupdater.brave.com/service/update2?test=hi")
 
+	// Requests for widevine should use update.googleapis.com directly without any proxy
+	requestBody = extensiontest.ExtensionRequestFnForXML(controller.WidivineExtensionID)("0.0.0")
+	expectedResponse = ""
+	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusTemporaryRedirect, expectedResponse, "https://update.googleapis.com/service/update2")
+
 	// Make sure a huge request body does not crash the server
 	data := make([]byte, 1024*1024*11) // 11 MiB
 	_, err := rand.Read(data)


### PR DESCRIPTION
Fix #45 

## Test Plan:

* With Browser
  * Navigate to https://bitmovin.com/demos/drm
  * Allow `Widevine` and verify the request for update is sent to `update.googleapis.com`
  * Ensure that the download is triggered from `*.gvt1.com` or `*.dl.google.com`

* With curl:
```
% curl -Ls -o /dev/null -w '%{url_effective}' -d '{"request":{"@os":"mac","@updater":"","acceptformat":"crx2,crx3","app":[{"appid":"oimompecagnajdejgnnjijobebaeigek","enabled":true,"installsource":"ondemand","ping":{"r":-2},"updatecheck":{},"version":"0.0.0.0"}],"arch":"x64","dedup":"cr","domainjoined":false,"hw":{"physmemory":16},"lang":"","nacl_arch":"x86-64","os":{"arch":"x86_64","platform":"Mac OS X","version":"10.15.5"},"prodchannel":"stable","prodversion":"83.1.12.20","protocol":"3.1","requestid":"{67dd796c-ac2d-46f9-a56d-6495e7c92640}","sessionid":"{fd35f289-fb9a-4a7c-8acf-9576b1d0c5eb}","updaterchannel":"stable","updaterversion":"83.1.12.20"}}' -H "Content-Type: application/json" -X POST http://localhost:8192/extensions
https://update.googleapis.com/service/update2/json
```