### PR TITLE
update ext buckets

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -3,7 +3,7 @@ services:
   app:
     build: .
     environment:
-      - S3_EXTENSIONS_BUCKET_HOST=brave-core-ext-dev.s3.bravesoftware.com
-      - S3_EXTENSIONS_BUCKET_HOST_TOR=brave-core-ext-tor-development.s3-us-west-2.amazonaws.com
+      - S3_EXTENSIONS_BUCKET_HOST=brave-ext-dev.s3.bravesoftware.com
+      - S3_EXTENSIONS_BUCKET_HOST_TOR=brave-ext-tor-dev.s3-us-west-2.amazonaws.com
     ports:
       - "80:8192"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -3,7 +3,7 @@ services:
   app:
     build: .
     environment:
-      - S3_EXTENSIONS_BUCKET_HOST=brave-ext-dev.s3.bravesoftware.com
-      - S3_EXTENSIONS_BUCKET_HOST_TOR=brave-ext-tor-dev.s3-us-west-2.amazonaws.com
+      - S3_EXTENSIONS_BUCKET_HOST=brave-core-ext-dev.s3.bravesoftware.com
+      - S3_EXTENSIONS_BUCKET_HOST_TOR=tor-dev.s3.bravesoftware.com
     ports:
       - "80:8192"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -4,6 +4,6 @@ services:
     build: .
     environment:
       - S3_EXTENSIONS_BUCKET_HOST=brave-core-ext-dev.s3.bravesoftware.com
-      - S3_EXTENSIONS_BUCKET_HOST_TOR=tor-dev.s3.bravesoftware.com
+      - S3_EXTENSIONS_BUCKET_HOST_TOR=tor-dev.bravesoftware.com
     ports:
       - "80:8192"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -4,7 +4,7 @@ services:
     build: .
     environment:
       - S3_EXTENSIONS_BUCKET_HOST=brave-ext.s3.brave.com
-      - S3_EXTENSIONS_BUCKET_HOST_TOR=brave-ext-tor.brave.com
+      - S3_EXTENSIONS_BUCKET_HOST_TOR=brave-ext-tor.bravesoftware.com
       - SENTRY_DSN=https://bdeadb80b91f490cbaa4d23d3250f58e@sentry.io/1862572
     logging:
       driver: awslogs

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -3,8 +3,8 @@ services:
   app:
     build: .
     environment:
-      - S3_EXTENSIONS_BUCKET_HOST=brave-ext.s3.brave.com
-      - S3_EXTENSIONS_BUCKET_HOST_TOR=brave-ext-tor.bravesoftware.com
+      - S3_EXTENSIONS_BUCKET_HOST=brave-core-ext.s3.brave.com
+      - S3_EXTENSIONS_BUCKET_HOST_TOR=tor.bravesoftware.com
       - SENTRY_DSN=https://bdeadb80b91f490cbaa4d23d3250f58e@sentry.io/1862572
     logging:
       driver: awslogs

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -3,8 +3,8 @@ services:
   app:
     build: .
     environment:
-      - S3_EXTENSIONS_BUCKET_HOST=brave-core-ext.s3.brave.com
-      - S3_EXTENSIONS_BUCKET_HOST_TOR=tor.bravesoftware.com
+      - S3_EXTENSIONS_BUCKET_HOST=brave-ext.s3.brave.com
+      - S3_EXTENSIONS_BUCKET_HOST_TOR=brave-ext-tor.brave.com
       - SENTRY_DSN=https://bdeadb80b91f490cbaa4d23d3250f58e@sentry.io/1862572
     logging:
       driver: awslogs


### PR DESCRIPTION
closes #https://github.com/brave/devops/issues/3238
will only deploy to production when all buckets are in synced and jenkins ext pipelines are updated