### PR TITLE
Fix #49: Download IPFS component from ipfs/ipfs-dev.bravesoftware.com

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,5 +5,6 @@ services:
     environment:
       - S3_EXTENSIONS_BUCKET_HOST=brave-core-ext-dev.s3.bravesoftware.com
       - S3_EXTENSIONS_BUCKET_HOST_TOR=tor-dev.bravesoftware.com
+      - S3_EXTENSIONS_BUCKET_HOST_IPFS=ipfs-dev.bravesoftware.com
     ports:
       - "80:8192"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -5,6 +5,7 @@ services:
     environment:
       - S3_EXTENSIONS_BUCKET_HOST=brave-core-ext.s3.brave.com
       - S3_EXTENSIONS_BUCKET_HOST_TOR=tor.bravesoftware.com
+      - S3_EXTENSIONS_BUCKET_HOST_IPFS=ipfs.bravesoftware.com
       - SENTRY_DSN=https://bdeadb80b91f490cbaa4d23d3250f58e@sentry.io/1862572
     logging:
       driver: awslogs

--- a/extension/data.go
+++ b/extension/data.go
@@ -318,5 +318,26 @@ var OfferedExtensions = Extensions{
 		Title:       "Brave Tor Client Updater (Mac)",
 		URL:         "",
 		Blacklisted: false,
+	}, {
+		ID:          "nljcddpbnaianmglkpkneakjaapinabi",
+		Version:     "1.0.1",
+		SHA256:      "1bfdea8bd9fcac4a7109e85cbfe76670f9cb1f716fb36d36e2d5f1bbaafb734a",
+		Title:       "Brave Ipfs Daemon Updater (Mac)",
+		URL:         "",
+		Blacklisted: false,
+	}, {
+		ID:          "lnbclahgobmjphilkalbhebakmblnbij",
+		Version:     "1.0.1",
+		SHA256:      "efc1b8a1ade508e2028c918c5b3451a568ec3ecce1703f01c09659403bc91526",
+		Title:       "Brave Ipfs Daemon Updater (Windows)",
+		URL:         "",
+		Blacklisted: false,
+	}, {
+		ID:          "oecghfpdmkjlhnfpmmjegjacfimiafjp",
+		Version:     "1.0.1",
+		SHA256:      "6641042f9f75f16066d28741cd699fc3a04df3e414629a7cda33d8df2b15c717",
+		Title:       "Brave Ipfs Daemon Updater (Linux)",
+		URL:         "",
+		Blacklisted: false,
 	},
 }

--- a/extension/extension_test.go
+++ b/extension/extension_test.go
@@ -91,6 +91,15 @@ func TestS3BucketForExtension(t *testing.T) {
 	torExtensionLinux, ok := allExtensionsMap["biahpgbdmdkfgndcmfiipgcebobojjkp"]
 	assert.True(t, ok)
 	assert.Equal(t, GetS3ExtensionBucketHost(torExtensionLinux.ID), "tor.bravesoftware.com")
+	ipfsExtensionMac, ok := allExtensionsMap["nljcddpbnaianmglkpkneakjaapinabi"]
+	assert.True(t, ok)
+	assert.Equal(t, GetS3ExtensionBucketHost(ipfsExtensionMac.ID), "ipfs.bravesoftware.com")
+	ipfsExtensionWin, ok := allExtensionsMap["lnbclahgobmjphilkalbhebakmblnbij"]
+	assert.True(t, ok)
+	assert.Equal(t, GetS3ExtensionBucketHost(ipfsExtensionWin.ID), "ipfs.bravesoftware.com")
+	ipfsExtensionLinux, ok := allExtensionsMap["oecghfpdmkjlhnfpmmjegjacfimiafjp"]
+	assert.True(t, ok)
+	assert.Equal(t, GetS3ExtensionBucketHost(ipfsExtensionLinux.ID), "ipfs.bravesoftware.com")
 	lightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
 	assert.True(t, ok)
 	assert.Equal(t, GetS3ExtensionBucketHost(lightThemeExtension.ID), "brave-core-ext.s3.brave.com")

--- a/extension/utils.go
+++ b/extension/utils.go
@@ -12,9 +12,26 @@ var torClientLinuxExtensionID = "biahpgbdmdkfgndcmfiipgcebobojjkp"
 // proxy url for downloading the tor client crx
 var TorClientExtensionIDs = []string{torClientMacExtensionID, torClientWindowsExtensionID, torClientLinuxExtensionID}
 
+var ipfsClientMacExtensionID = "nljcddpbnaianmglkpkneakjaapinabi"
+var ipfsClientWindowsExtensionID = "lnbclahgobmjphilkalbhebakmblnbij"
+var ipfsClientLinuxExtensionID = "oecghfpdmkjlhnfpmmjegjacfimiafjp"
+
+// ipfsClientExtensionIDs is used to add an exception to return the dedicated
+// proxy url for downloading the ipfs crx
+var ipfsClientExtensionIDs = []string{ipfsClientMacExtensionID, ipfsClientWindowsExtensionID, ipfsClientLinuxExtensionID}
+
 func isTorExtension(id string) bool {
 	for _, torID := range TorClientExtensionIDs {
 		if torID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func isIPFSExtension(id string) bool {
+	for _, ipfsID := range ipfsClientExtensionIDs {
+		if ipfsID == id {
 			return true
 		}
 	}
@@ -25,6 +42,10 @@ func isTorExtension(id string) bool {
 func GetS3ExtensionBucketHost(id string) string {
 	if isTorExtension(id) {
 		return GetS3TorExtensionBucketHost()
+	}
+
+	if isIPFSExtension(id) {
+		return GetS3IPFSExtensionBucketHost()
 	}
 
 	s3BucketHost, ok := os.LookupEnv("S3_EXTENSIONS_BUCKET_HOST")
@@ -39,6 +60,15 @@ func GetS3TorExtensionBucketHost() string {
 	s3BucketHost, ok := os.LookupEnv("S3_EXTENSIONS_BUCKET_HOST_TOR")
 	if !ok {
 		s3BucketHost = "tor.bravesoftware.com"
+	}
+	return s3BucketHost
+}
+
+// GetS3IPFSExtensionBucketHost returns the url to use for accessing go-ipfs client crx
+func GetS3IPFSExtensionBucketHost() string {
+	s3BucketHost, ok := os.LookupEnv("S3_EXTENSIONS_BUCKET_HOST_IPFS")
+	if !ok {
+		s3BucketHost = "ipfs.bravesoftware.com"
 	}
 	return s3BucketHost
 }


### PR DESCRIPTION
Fix #49 

## Test Plan

```
1. $ curl -Ls -d '{"request":{"@os":"mac","@updater":"","acceptformat":"crx2,crx3","app":[{"appid":"nljcddpbnaianmglkpkneakjaapinabi","enabled":true,"installsource":"ondemand","ping":{"r":-2},"updatecheck":{},"version":"0.0.0.0"}],"arch":"x64","dedup":"cr","domainjoined":false,"hw":{"physmemory":16},"lang":"","nacl_arch":"x86-64","os":{"arch":"x86_64","platform":"Mac OS X","version":"10.15.5"},"prodchannel":"stable","prodversion":"83.1.12.20","protocol":"3.1","requestid":"{67dd796c-ac2d-46f9-a56d-6495e7c92640}","sessionid":"{fd35f289-fb9a-4a7c-8acf-9576b1d0c5eb}","updaterchannel":"stable","updaterversion":"83.1.12.20"}}' -H "Content-Type: application/json" -X POST http://localhost:8192/extensions
)]}'
{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"nljcddpbnaianmglkpkneakjaapinabi","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://ipfs.bravesoftware.com/release/nljcddpbnaianmglkpkneakjaapinabi/extension_1_0_1.crx"}]},"manifest":{"version":"1.0.1","packages":{"package":[{"name":"extension_1_0_1.crx","hash_sha256":"7fa540d3ebc47aed89d8c199c745d7adec374ff45d279530fc0126ee29aa1b83","required":true}]}}}}]}}

2. $ curl -Ls -d '{"request":{"@os":"mac","@updater":"","acceptformat":"crx2,crx3","app":[{"appid":"lnbclahgobmjphilkalbhebakmblnbij","enabled":true,"installsource":"ondemand","ping":{"r":-2},"updatecheck":{},"version":"0.0.0.0"}],"arch":"x64","dedup":"cr","domainjoined":false,"hw":{"physmemory":16},"lang":"","nacl_arch":"x86-64","os":{"arch":"x86_64","platform":"Mac OS X","version":"10.15.5"},"prodchannel":"stable","prodversion":"83.1.12.20","protocol":"3.1","requestid":"{67dd796c-ac2d-46f9-a56d-6495e7c92640}","sessionid":"{fd35f289-fb9a-4a7c-8acf-9576b1d0c5eb}","updaterchannel":"stable","updaterversion":"83.1.12.20"}}' -H "Content-Type: application/json" -X POST http://localhost:8192/extensions
)]}'
{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"lnbclahgobmjphilkalbhebakmblnbij","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://ipfs.bravesoftware.com/release/lnbclahgobmjphilkalbhebakmblnbij/extension_1_0_1.crx"}]},"manifest":{"version":"1.0.1","packages":{"package":[{"name":"extension_1_0_1.crx","hash_sha256":"908693141d0f0b993187718d299a5d5c23ea64f586797daa0b3038b1d5498325","required":true}]}}}}]}}

3. $ curl -Ls -d '{"request":{"@os":"mac","@updater":"","acceptformat":"crx2,crx3","app":[{"appid":"oecghfpdmkjlhnfpmmjegjacfimiafjp","enabled":true,"installsource":"ondemand","ping":{"r":-2},"updatecheck":{},"version":"0.0.0.0"}],"arch":"x64","dedup":"cr","domainjoined":false,"hw":{"physmemory":16},"lang":"","nacl_arch":"x86-64","os":{"arch":"x86_64","platform":"Mac OS X","version":"10.15.5"},"prodchannel":"stable","prodversion":"83.1.12.20","protocol":"3.1","requestid":"{67dd796c-ac2d-46f9-a56d-6495e7c92640}","sessionid":"{fd35f289-fb9a-4a7c-8acf-9576b1d0c5eb}","updaterchannel":"stable","updaterversion":"83.1.12.20"}}' -H "Content-Type: application/json" -X POST http://localhost:8192/extensions
)]}'
{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"oecghfpdmkjlhnfpmmjegjacfimiafjp","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://ipfs.bravesoftware.com/release/oecghfpdmkjlhnfpmmjegjacfimiafjp/extension_1_0_1.crx"}]},"manifest":{"version":"1.0.1","packages":{"package":[{"name":"extension_1_0_1.crx","hash_sha256":"30ac9774828d65e7c13403e02f8a1cfe2d7b6604bd901890d875d537c15b8b90","required":true}]}}}}]}}
```

For dev environment:
```
1. Navigate to brave://flags and search for IPFS. Set it to enable and restart.
2. Navigate to ipfs://QmQNp3wTAPM3zjMGWU6UxJVTRqV3ySw3kMqTuQnTdunmCS in a new tab - This displays an infobar to enable IPFS.
3. Click enable and wait for the component to download. You can check these directories to verify if the components are downloaded correctly.
- For macOS: <user-dir>/nljcddpbnaianmglkpkneakjaapinabi/
- For linux: <user-dir>/oecghfpdmkjlhnfpmmjegjacfimiafjp/
- For windows: <user-dir>/lnbclahgobmjphilkalbhebakmblnbij/
3. Sometimes a restart is needed for the ipfs URLs to load.
4. If the component is working correctly - ipfs://QmQNp3wTAPM3zjMGWU6UxJVTRqV3ySw3kMqTuQnTdunmCS - should load a cat image.
```