### PR TITLE
Ensuring concurrent extension map access is safe

### DIFF
--- a/extension/json_test.go
+++ b/extension/json_test.go
@@ -2,13 +2,15 @@ package extension
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/brave/go-update/extension/extensiontest"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestUpdateResponseMarshalJSON(t *testing.T) {
-	allExtensionsMap := LoadExtensionsIntoMap(&OfferedExtensions)
+	allExtensionsMap := NewExtensionMap()
+	allExtensionsMap.StoreExtensions(&OfferedExtensions)
 	// Empty extension list returns a blank JSON update
 	updateResponse := UpdateResponse{}
 	jsonData, err := json.Marshal(&updateResponse)
@@ -16,7 +18,7 @@ func TestUpdateResponseMarshalJSON(t *testing.T) {
 	expectedOutput := `{"response":{"protocol":"3.1","server":"prod","app":null}}`
 	assert.Equal(t, expectedOutput, string(jsonData))
 
-	darkThemeExtension, ok := allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	darkThemeExtension, ok := allExtensionsMap.Load("bfdgpgibhagkpdlnjonhkabjoijopoge")
 	assert.True(t, ok)
 
 	// Single extension list returns a single JSON update
@@ -27,9 +29,9 @@ func TestUpdateResponseMarshalJSON(t *testing.T) {
 	assert.Equal(t, expectedOutput, string(jsonData))
 
 	// Multiple extensions returns a multiple extension JSON update
-	lightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
+	lightThemeExtension, ok := allExtensionsMap.Load("ldimlcelhnjgpjjemdjokpgeeikdinbm")
 	assert.True(t, ok)
-	darkThemeExtension, ok = allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	darkThemeExtension, ok = allExtensionsMap.Load("bfdgpgibhagkpdlnjonhkabjoijopoge")
 	assert.True(t, ok)
 	updateResponse = []Extension{lightThemeExtension, darkThemeExtension}
 	jsonData, err = json.Marshal(&updateResponse)
@@ -89,13 +91,14 @@ func TestUpdateRequestUnmarshalJSON(t *testing.T) {
 func TestWebStoreUpdateResponseMarshalJSON(t *testing.T) {
 	// No extensions returns blank update response
 	updateResponse := WebStoreUpdateResponse{}
-	allExtensionsMap := LoadExtensionsIntoMap(&OfferedExtensions)
+	allExtensionsMap := NewExtensionMap()
+	allExtensionsMap.StoreExtensions(&OfferedExtensions)
 	jsonData, err := json.Marshal(&updateResponse)
 	assert.Nil(t, err)
 	expectedOutput := `{"gupdate":{"protocol":"3.1","server":"prod","app":null}}`
 	assert.Equal(t, expectedOutput, string(jsonData))
 
-	darkThemeExtension, ok := allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	darkThemeExtension, ok := allExtensionsMap.Load("bfdgpgibhagkpdlnjonhkabjoijopoge")
 	assert.True(t, ok)
 
 	// Single extension list returns a single JSON update
@@ -106,9 +109,9 @@ func TestWebStoreUpdateResponseMarshalJSON(t *testing.T) {
 	assert.Equal(t, expectedOutput, string(jsonData))
 
 	// Multiple extensions returns a multiple extension JSON webstore update
-	lightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
+	lightThemeExtension, ok := allExtensionsMap.Load("ldimlcelhnjgpjjemdjokpgeeikdinbm")
 	assert.True(t, ok)
-	darkThemeExtension, ok = allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	darkThemeExtension, ok = allExtensionsMap.Load("bfdgpgibhagkpdlnjonhkabjoijopoge")
 	assert.True(t, ok)
 	updateResponse = WebStoreUpdateResponse{lightThemeExtension, darkThemeExtension}
 	jsonData, err = json.Marshal(&updateResponse)

--- a/extension/xml_test.go
+++ b/extension/xml_test.go
@@ -2,13 +2,15 @@ package extension
 
 import (
 	"encoding/xml"
+	"testing"
+
 	"github.com/brave/go-update/extension/extensiontest"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestUpdateResponseMarshalXML(t *testing.T) {
-	allExtensionsMap := LoadExtensionsIntoMap(&OfferedExtensions)
+	allExtensionsMap := NewExtensionMap()
+	allExtensionsMap.StoreExtensions(&OfferedExtensions)
 	// Empty extension list returns a blank XML update
 	updateResponse := UpdateResponse{}
 	xmlData, err := xml.Marshal(&updateResponse)
@@ -16,7 +18,7 @@ func TestUpdateResponseMarshalXML(t *testing.T) {
 	expectedOutput := `<response protocol="3.1" server="prod"></response>`
 	assert.Equal(t, expectedOutput, string(xmlData))
 
-	darkThemeExtension, ok := allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	darkThemeExtension, ok := allExtensionsMap.Load("bfdgpgibhagkpdlnjonhkabjoijopoge")
 	assert.True(t, ok)
 
 	// Single extension list returns a single XML update
@@ -40,9 +42,9 @@ func TestUpdateResponseMarshalXML(t *testing.T) {
 	assert.Equal(t, expectedOutput, string(xmlData))
 
 	// Multiple extensions returns a multiple extension XML update
-	lightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
+	lightThemeExtension, ok := allExtensionsMap.Load("ldimlcelhnjgpjjemdjokpgeeikdinbm")
 	assert.True(t, ok)
-	darkThemeExtension, ok = allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	darkThemeExtension, ok = allExtensionsMap.Load("bfdgpgibhagkpdlnjonhkabjoijopoge")
 	assert.True(t, ok)
 	updateResponse = []Extension{lightThemeExtension, darkThemeExtension}
 	xmlData, err = xml.Marshal(&updateResponse)
@@ -131,13 +133,14 @@ func TestUpdateRequestUnmarshalXML(t *testing.T) {
 func TestWebStoreUpdateResponseMarshalXML(t *testing.T) {
 	// No extensions returns blank update response
 	updateResponse := WebStoreUpdateResponse{}
-	allExtensionsMap := LoadExtensionsIntoMap(&OfferedExtensions)
+	allExtensionsMap := NewExtensionMap()
+	allExtensionsMap.StoreExtensions(&OfferedExtensions)
 	xmlData, err := xml.Marshal(&updateResponse)
 	assert.Nil(t, err)
 	expectedOutput := `<gupdate protocol="3.1" server="prod"></gupdate>`
 	assert.Equal(t, expectedOutput, string(xmlData))
 
-	darkThemeExtension, ok := allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	darkThemeExtension, ok := allExtensionsMap.Load("bfdgpgibhagkpdlnjonhkabjoijopoge")
 	assert.True(t, ok)
 
 	// Single extension list returns a single XML update
@@ -152,9 +155,9 @@ func TestWebStoreUpdateResponseMarshalXML(t *testing.T) {
 	assert.Equal(t, expectedOutput, string(xmlData))
 
 	// Multiple extensions returns a multiple extension XML webstore update
-	lightThemeExtension, ok := allExtensionsMap["ldimlcelhnjgpjjemdjokpgeeikdinbm"]
+	lightThemeExtension, ok := allExtensionsMap.Load("ldimlcelhnjgpjjemdjokpgeeikdinbm")
 	assert.True(t, ok)
-	darkThemeExtension, ok = allExtensionsMap["bfdgpgibhagkpdlnjonhkabjoijopoge"]
+	darkThemeExtension, ok = allExtensionsMap.Load("bfdgpgibhagkpdlnjonhkabjoijopoge")
 	assert.True(t, ok)
 	updateResponse = WebStoreUpdateResponse{lightThemeExtension, darkThemeExtension}
 	xmlData, err = xml.Marshal(&updateResponse)


### PR DESCRIPTION
Under heavy-load our application was panicing with `fatal error: concurrent map read and map write` due to the extensions map refresh goroutine writing whilst a read was occurring.