### PR TITLE
fix: Add missing out object to puff operation

### DIFF
--- a/omaha/v4/protocol_test.go
+++ b/omaha/v4/protocol_test.go
@@ -165,6 +165,9 @@ func TestResponseMarshalJSONV40(t *testing.T) {
 		if prevObj, prevOK := puffOp["previous"].(map[string]interface{}); !prevOK || prevObj["sha256"] != "test-fp" {
 			t.Errorf("Expected puff operation to have previous.sha256 'test-fp'")
 		}
+		if outObj, outOK := puffOp["out"].(map[string]interface{}); !outOK || outObj["sha256"] != "test-sha256" {
+			t.Errorf("Expected puff operation to have out.sha256 'test-sha256'")
+		}
 
 		// Check crx3 operation in diff pipeline
 		crx3OpDiff := diffOperations[2].(map[string]interface{})


### PR DESCRIPTION
This PR adds the missing `out` object:

> For `type == "puff"`: Apply a differential Puffin patch produced by a previous
>     operation to a payload stored in the cache. The patch is generated using
>     [Puffin](https://chromium.googlesource.com/chromium/src.git/+/main/third_party/puffin/README.md).
>  *  `previous`: A `hash` object representing the file to apply this patch to.
>     This field is required.
>  *  `out`: A `hash` object representing the file produced from this patch. This
>     field is required.

see [docs](https://chromium.googlesource.com/chromium/src/+/main/docs/updater/protocol_4.md#update-checks-body-update-check-response-objects-update-check-response-7), [src](https://source.chromium.org/chromium/chromium/src/+/main:components/update_client/pipeline.cc;l=281;drc=8a5af199283ad2c25a4a0743d90d43ddc41399b4)