### PR TITLE
fix: Add graceful handling for component version mismatch and invalid IDs

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -346,8 +346,7 @@ func UpdateExtensions(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 
-	// Use the generic FilterForUpdates function
-	updateResponse := extension.FilterForUpdates(updateRequest, AllExtensionsMap)
+	updateResponse := extension.ProcessExtensionRequests(updateRequest, AllExtensionsMap)
 
 	// Use the same protocol version for response as the request for v4
 	// Otherwise default to 3.1 for backward compatibility

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -76,17 +76,15 @@ func FilterForUpdates(extensions Extensions, allExtensionsMap *ExtensionsMap) Ex
 	defer allExtensionsMap.RUnlock()
 	for _, extensionBeingChecked := range extensions {
 		foundExtension, ok := allExtensionsMap.data[extensionBeingChecked.ID]
-		if ok {
+		if ok && !foundExtension.Blacklisted {
 			status := CompareVersions(extensionBeingChecked.Version, foundExtension.Version)
-			if !foundExtension.Blacklisted && status <= 0 {
-				if status == 0 {
-					foundExtension.Status = "noupdate"
-				}
-
-				foundExtension.FP = extensionBeingChecked.FP
-
-				filteredExtensions = append(filteredExtensions, foundExtension)
+			// Skip update if client version is equal to or newer than server version
+			if status >= 0 {
+				foundExtension.Status = "noupdate"
 			}
+
+			foundExtension.FP = extensionBeingChecked.FP
+			filteredExtensions = append(filteredExtensions, foundExtension)
 		}
 	}
 	return filteredExtensions

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -68,9 +68,9 @@ func CompareVersions(version1 string, version2 string) int {
 	return 0
 }
 
-// FilterForUpdates filters extensions down to only the extensions that are being checked,
-// and only the ones that we have updates for.
-func FilterForUpdates(extensions Extensions, allExtensionsMap *ExtensionsMap) Extensions {
+// ProcessExtensionRequests processes extension update requests and returns all requested extensions
+// with their appropriate update status (either available update or "noupdate").
+func ProcessExtensionRequests(extensions Extensions, allExtensionsMap *ExtensionsMap) Extensions {
 	filteredExtensions := Extensions{}
 	allExtensionsMap.RLock()
 	defer allExtensionsMap.RUnlock()

--- a/extension/extension_test.go
+++ b/extension/extension_test.go
@@ -57,12 +57,13 @@ func TestFilterForUpdates(t *testing.T) {
 	// Check that even if a URL is provided, we use the server's URL
 	assert.Equal(t, lightThemeExtension.URL, check[0].URL)
 
-	// Newer extensions have no items returned
+	// Newer extensions are returned with noupdate status
 	newerExtensionCheck := lightThemeExtension
 	newerExtensionCheck.Version = "2.1.0"
 	extensions := Extensions{newerExtensionCheck}
 	check = FilterForUpdates(extensions, testExtensionsMap)
-	assert.Equal(t, 0, len(check))
+	assert.Equal(t, 1, len(check))
+	assert.Equal(t, "noupdate", check[0].Status)
 
 	// 2 outdated extensions both get returned from 1 check
 	olderExtensionCheck2 := darkThemeExtension

--- a/extension/extension_test.go
+++ b/extension/extension_test.go
@@ -25,7 +25,7 @@ func TestCompareVersions(t *testing.T) {
 	assert.Equal(t, -1, CompareVersions("zugzug.1.1", "1.1.daboo"))
 }
 
-func TestFilterForUpdates(t *testing.T) {
+func TestProcessExtensionRequests(t *testing.T) {
 	allExtensionsMap := NewExtensionMap()
 	allExtensionsMap.StoreExtensions(&OfferedExtensions)
 	lightThemeExtension, ok := allExtensionsMap.Load("ldimlcelhnjgpjjemdjokpgeeikdinbm")
@@ -39,14 +39,14 @@ func TestFilterForUpdates(t *testing.T) {
 
 	// No updates when nothing to check
 	emptyExtensions := Extensions{}
-	check := FilterForUpdates(emptyExtensions, testExtensionsMap)
+	check := ProcessExtensionRequests(emptyExtensions, testExtensionsMap)
 	assert.Equal(t, 0, len(check))
 
 	olderExtensionCheck1 := lightThemeExtension
 	olderExtensionCheck1.Version = "0.1.0"
 	outdatedExtensionCheck := Extensions{olderExtensionCheck1}
 
-	check = FilterForUpdates(outdatedExtensionCheck, testExtensionsMap)
+	check = ProcessExtensionRequests(outdatedExtensionCheck, testExtensionsMap)
 	assert.Equal(t, 1, len(check))
 
 	assert.Equal(t, lightThemeExtension.ID, check[0].ID)
@@ -61,7 +61,7 @@ func TestFilterForUpdates(t *testing.T) {
 	newerExtensionCheck := lightThemeExtension
 	newerExtensionCheck.Version = "2.1.0"
 	extensions := Extensions{newerExtensionCheck}
-	check = FilterForUpdates(extensions, testExtensionsMap)
+	check = ProcessExtensionRequests(extensions, testExtensionsMap)
 	assert.Equal(t, 1, len(check))
 	assert.Equal(t, "noupdate", check[0].Status)
 
@@ -69,7 +69,7 @@ func TestFilterForUpdates(t *testing.T) {
 	olderExtensionCheck2 := darkThemeExtension
 	olderExtensionCheck2.Version = "0.1.0"
 	extensions = Extensions{olderExtensionCheck1, olderExtensionCheck2}
-	check = FilterForUpdates(extensions, testExtensionsMap)
+	check = ProcessExtensionRequests(extensions, testExtensionsMap)
 	assert.Equal(t, 2, len(check))
 	assert.Equal(t, olderExtensionCheck1.ID, check[0].ID)
 	assert.Equal(t, olderExtensionCheck2.ID, check[1].ID)
@@ -81,7 +81,7 @@ func TestFilterForUpdates(t *testing.T) {
 		elem.Blacklisted = true
 		allExtensionsBlacklistedMap.data[k] = elem
 	}
-	check = FilterForUpdates(outdatedExtensionCheck, allExtensionsBlacklistedMap)
+	check = ProcessExtensionRequests(outdatedExtensionCheck, allExtensionsBlacklistedMap)
 	assert.Equal(t, 0, len(check))
 }
 

--- a/omaha/v3/response.go
+++ b/omaha/v3/response.go
@@ -13,9 +13,11 @@ type UpdateResponse []extension.Extension
 
 // GetUpdateStatus determines the update status based on extension data
 func GetUpdateStatus(extension extension.Extension) string {
-	if extension.Status == "noupdate" {
-		return "noupdate"
+	// Return the existing status if already set (indicates no update available or an error)
+	if extension.Status != "" {
+		return extension.Status
 	}
+	// Unassigned status implies an available update
 	return "ok"
 }
 

--- a/omaha/v3/response_test.go
+++ b/omaha/v3/response_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"strings"
 	"testing"
@@ -25,11 +26,43 @@ func TestResponseMarshalJSON(t *testing.T) {
 			Version: "1.0.0",
 			Status:  "error-unknownApplication",
 		},
+		{
+			ID:      "test-restricted-ext",
+			Version: "1.0.0",
+			Status:  "restricted",
+		},
 	}
 	jsonData, err := updateResponse.MarshalJSON()
 	assert.Nil(t, err)
-	expectedOutput := `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"test-noupdate-ext","status":"ok","updatecheck":{"status":"noupdate"}},{"appid":"test-unknown-ext","status":"ok","updatecheck":{"status":"error-unknownApplication"}}]}}`
-	assert.Equal(t, expectedOutput, string(jsonData))
+
+	// Parse the actual response
+	var actual map[string]interface{}
+	err = json.Unmarshal(jsonData, &actual)
+	assert.Nil(t, err)
+
+	// Verify the mixed status extensions case
+	resp := actual["response"].(map[string]interface{})
+	assert.Equal(t, "3.1", resp["protocol"])
+	assert.Equal(t, "prod", resp["server"])
+
+	apps := resp["app"].([]interface{})
+	assert.Equal(t, 3, len(apps))
+
+	// Check each extension has the correct status and no URLs/manifest for non-"ok" statuses
+	expectedStatuses := []string{"noupdate", "error-unknownApplication", "restricted"}
+	for i, expectedStatus := range expectedStatuses {
+		app := apps[i].(map[string]interface{})
+		assert.Equal(t, "ok", app["status"]) // App status is always "ok"
+
+		updateCheck := app["updatecheck"].(map[string]interface{})
+		assert.Equal(t, expectedStatus, updateCheck["status"])
+
+		// No URLs or manifest for non-"ok" statuses
+		_, hasURLs := updateCheck["urls"]
+		_, hasManifest := updateCheck["manifest"]
+		assert.False(t, hasURLs, "Non-ok status should not have URLs")
+		assert.False(t, hasManifest, "Non-ok status should not have manifest")
+	}
 
 	darkThemeExtension, ok := allExtensionsMap.Load("bfdgpgibhagkpdlnjonhkabjoijopoge")
 	assert.True(t, ok)
@@ -38,8 +71,39 @@ func TestResponseMarshalJSON(t *testing.T) {
 	updateResponse = []extension.Extension{darkThemeExtension}
 	jsonData, err = updateResponse.MarshalJSON()
 	assert.Nil(t, err)
-	expectedOutput = `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost(darkThemeExtension.ID) + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","fp":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834","hash_sha256":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834","required":true}]}}}}]}}`
-	assert.Equal(t, expectedOutput, string(jsonData))
+
+	err = json.Unmarshal(jsonData, &actual)
+	assert.Nil(t, err)
+
+	// Verify the single extension case
+	resp = actual["response"].(map[string]interface{})
+	assert.Equal(t, "3.1", resp["protocol"])
+	assert.Equal(t, "prod", resp["server"])
+
+	apps = resp["app"].([]interface{})
+	assert.Equal(t, 1, len(apps))
+	app := apps[0].(map[string]interface{})
+	assert.Equal(t, "bfdgpgibhagkpdlnjonhkabjoijopoge", app["appid"])
+	assert.Equal(t, "ok", app["status"])
+
+	updateCheck := app["updatecheck"].(map[string]interface{})
+	assert.Equal(t, "ok", updateCheck["status"])
+
+	urls := updateCheck["urls"].(map[string]interface{})
+	urlList := urls["url"].([]interface{})
+	assert.Equal(t, 1, len(urlList))
+	url := urlList[0].(map[string]interface{})
+	assert.Contains(t, url["codebase"], "bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx")
+
+	manifest := updateCheck["manifest"].(map[string]interface{})
+	assert.Equal(t, "1.0.0", manifest["version"])
+	packages := manifest["packages"].(map[string]interface{})
+	packageList := packages["package"].([]interface{})
+	assert.Equal(t, 1, len(packageList))
+	pkg := packageList[0].(map[string]interface{})
+	assert.Equal(t, "extension_1_0_0.crx", pkg["name"])
+	assert.Equal(t, "ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834", pkg["hash_sha256"])
+	assert.Equal(t, true, pkg["required"])
 
 	// Multiple extensions returns a multiple extension JSON update
 	lightThemeExtension, ok := allExtensionsMap.Load("ldimlcelhnjgpjjemdjokpgeeikdinbm")
@@ -49,8 +113,25 @@ func TestResponseMarshalJSON(t *testing.T) {
 	updateResponse = []extension.Extension{lightThemeExtension, darkThemeExtension}
 	jsonData, err = updateResponse.MarshalJSON()
 	assert.Nil(t, err)
-	expectedOutput = `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost(lightThemeExtension.ID) + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","fp":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","hash_sha256":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","required":true}]}}}},{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost(darkThemeExtension.ID) + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","fp":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834","hash_sha256":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834","required":true}]}}}}]}}`
-	assert.Equal(t, expectedOutput, string(jsonData))
+
+	err = json.Unmarshal(jsonData, &actual)
+	assert.Nil(t, err)
+
+	// Verify the multiple extension case
+	resp = actual["response"].(map[string]interface{})
+	assert.Equal(t, "3.1", resp["protocol"])
+	assert.Equal(t, "prod", resp["server"])
+
+	apps = resp["app"].([]interface{})
+	assert.Equal(t, 2, len(apps))
+
+	// First app should be lightThemeExtension
+	app = apps[0].(map[string]interface{})
+	assert.Equal(t, "ldimlcelhnjgpjjemdjokpgeeikdinbm", app["appid"])
+
+	// Second app should be darkThemeExtension
+	app = apps[1].(map[string]interface{})
+	assert.Equal(t, "bfdgpgibhagkpdlnjonhkabjoijopoge", app["appid"])
 }
 
 func TestWebStoreResponseMarshalJSON(t *testing.T) {

--- a/omaha/v4/response.go
+++ b/omaha/v4/response.go
@@ -88,16 +88,20 @@ func (r *UpdateResponse) MarshalJSON() ([]byte, error) {
 	validate := validator.New()
 
 	for _, ext := range *r {
-		// Check if SHA256 is empty
-		if ext.SHA256 == "" {
-			return nil, fmt.Errorf("extension %s has empty SHA256", ext.ID)
+		updateStatus := GetUpdateStatus(ext)
+		app := App{
+			AppID:       ext.ID,
+			Status:      "ok",
+			UpdateCheck: UpdateCheck{Status: updateStatus},
 		}
 
-		app := App{AppID: ext.ID, Status: "ok"}
-		updateStatus := GetUpdateStatus(ext)
-		app.UpdateCheck = UpdateCheck{Status: updateStatus}
-
+		// Further processing makes sense only if there is an update available
 		if updateStatus == "ok" {
+			// Check if SHA256 is empty
+			if ext.SHA256 == "" {
+				return nil, fmt.Errorf("extension %s has empty SHA256", ext.ID)
+			}
+
 			app.UpdateCheck.NextVersion = ext.Version
 
 			// Create pipeline with operations

--- a/omaha/v4/response.go
+++ b/omaha/v4/response.go
@@ -21,9 +21,11 @@ type UpdateResponse []extension.Extension
 
 // GetUpdateStatus determines the update status based on extension data
 func GetUpdateStatus(extension extension.Extension) string {
-	if extension.Status == "noupdate" {
-		return "noupdate"
+	// Return the existing status if already set (indicates no update available or an error)
+	if extension.Status != "" {
+		return extension.Status
 	}
+	// Unassigned status implies an available update
 	return "ok"
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -209,14 +209,25 @@ func TestUpdateExtensionsXMLV3(t *testing.T) {
 
 	// Single extension greater version
 	requestBody = lightThemeExtension("2.0.0")
-	expectedResponse = "<response protocol=\"3.1\" server=\"prod\"></response>"
+	expectedResponse = `<response protocol="3.1" server="prod">
+    <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm">
+        <updatecheck status="noupdate"></updatecheck>
+    </app>
+</response>`
 	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	lightAndDarkThemeRequest := extensiontest.ExtensionRequestFnForTwoXML("ldimlcelhnjgpjjemdjokpgeeikdinbm", "bfdgpgibhagkpdlnjonhkabjoijopoge")
 
 	// Multiple components with none out of date
 	requestBody = lightAndDarkThemeRequest("70.0.0", "70.0.0")
-	expectedResponse = "<response protocol=\"3.1\" server=\"prod\"></response>"
+	expectedResponse = `<response protocol="3.1" server="prod">
+    <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm">
+        <updatecheck status="noupdate"></updatecheck>
+    </app>
+    <app appid="bfdgpgibhagkpdlnjonhkabjoijopoge">
+        <updatecheck status="noupdate"></updatecheck>
+    </app>
+</response>`
 	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Only one components out of date
@@ -234,12 +245,18 @@ func TestUpdateExtensionsXMLV3(t *testing.T) {
             </manifest>
         </updatecheck>
     </app>
+    <app appid="bfdgpgibhagkpdlnjonhkabjoijopoge">
+        <updatecheck status="noupdate"></updatecheck>
+    </app>
 </response>`
 	testCall(t, server, http.MethodPost, contentTypeXML, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Other component of 2 out of date
 	requestBody = lightAndDarkThemeRequest("70.0.0", "0.0.0")
 	expectedResponse = `<response protocol="3.1" server="prod">
+    <app appid="ldimlcelhnjgpjjemdjokpgeeikdinbm">
+        <updatecheck status="noupdate"></updatecheck>
+    </app>
     <app appid="bfdgpgibhagkpdlnjonhkabjoijopoge">
         <updatecheck status="ok">
             <urls>
@@ -460,24 +477,24 @@ func TestUpdateExtensionsV3JSON(t *testing.T) {
 
 	// Single extension greater version
 	requestBody = lightThemeExtension("2.0.0")
-	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":null}}`
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"noupdate"}}]}}`
 	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	lightAndDarkThemeRequest := extensiontest.ExtensionRequestFnForTwoJSON("ldimlcelhnjgpjjemdjokpgeeikdinbm", "bfdgpgibhagkpdlnjonhkabjoijopoge")
 
 	// Multiple components with none out of date
 	requestBody = lightAndDarkThemeRequest("70.0.0", "70.0.0")
-	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":null}}`
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"noupdate"}},{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"noupdate"}}]}}`
 	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Only one components out of date
 	requestBody = lightAndDarkThemeRequest("0.0.0", "70.0.0")
-	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost(lightThemeExtensionID) + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","fp":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","hash_sha256":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","required":true}]}}}}]}}`
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost(lightThemeExtensionID) + `/release/ldimlcelhnjgpjjemdjokpgeeikdinbm/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","fp":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","hash_sha256":"1c714fadd4208c63f74b707e4c12b81b3ad0153c37de1348fa810dd47cfc5618","required":true}]}}}},{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"noupdate"}}]}}`
 	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Other component of 2 out of date
 	requestBody = lightAndDarkThemeRequest("70.0.0", "0.0.0")
-	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost(darkThemeExtensionID) + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","fp":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834","hash_sha256":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834","required":true}]}}}}]}}`
+	expectedResponse = jsonPrefix + `{"response":{"protocol":"3.1","server":"prod","app":[{"appid":"ldimlcelhnjgpjjemdjokpgeeikdinbm","status":"ok","updatecheck":{"status":"noupdate"}},{"appid":"bfdgpgibhagkpdlnjonhkabjoijopoge","status":"ok","updatecheck":{"status":"ok","urls":{"url":[{"codebase":"https://` + extension.GetS3ExtensionBucketHost(darkThemeExtensionID) + `/release/bfdgpgibhagkpdlnjonhkabjoijopoge/extension_1_0_0.crx"}]},"manifest":{"version":"1.0.0","packages":{"package":[{"name":"extension_1_0_0.crx","fp":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834","hash_sha256":"ae517d6273a4fc126961cb026e02946db4f9dbb58e3d9bc29f5e1270e3ce9834","required":true}]}}}}]}}`
 	testCall(t, server, http.MethodPost, contentTypeJSON, "", requestBody, http.StatusOK, expectedResponse, "")
 
 	// Both components need updates
@@ -809,7 +826,21 @@ func TestUpdateExtensionsV4JSON(t *testing.T) {
 
 	appsInterface, ok = respObj["apps"]
 	assert.True(t, ok, "apps should be present")
-	assert.Nil(t, appsInterface, "apps should be null")
+	appsArray, ok = appsInterface.([]interface{})
+	assert.True(t, ok, "apps should be an array")
+	assert.Equal(t, 1, len(appsArray), "apps should contain 1 item")
+
+	appInterface = appsArray[0]
+	app, ok = appInterface.(map[string]interface{})
+	assert.True(t, ok, "app should be a map")
+	assert.Equal(t, lightThemeExtensionID, app["appid"])
+	assert.Equal(t, "ok", app["status"])
+
+	updatecheckInterface, ok = app["updatecheck"]
+	assert.True(t, ok, "updatecheck should be present")
+	updatecheck, ok = updatecheckInterface.(map[string]interface{})
+	assert.True(t, ok, "updatecheck should be a map")
+	assert.Equal(t, "noupdate", updatecheck["status"])
 
 	// Multiple extensions test - create a request with light and dark theme extensions
 	darkThemeExtensionID := "bfdgpgibhagkpdlnjonhkabjoijopoge"
@@ -851,12 +882,17 @@ func TestUpdateExtensionsV4JSON(t *testing.T) {
 	assert.True(t, ok, "apps should be present")
 	appsArray, ok = appsInterface.([]interface{})
 	assert.True(t, ok, "apps should be an array")
-	assert.Equal(t, 1, len(appsArray), "apps should contain 1 item")
+	assert.Equal(t, 2, len(appsArray), "apps should contain 2 items")
 
-	appInterface = appsArray[0]
-	app, ok = appInterface.(map[string]interface{})
+	app1Object := appsArray[0]
+	app1, ok := app1Object.(map[string]interface{})
 	assert.True(t, ok, "app should be a map")
-	assert.Equal(t, lightThemeExtensionID, app["appid"])
+	assert.Equal(t, lightThemeExtensionID, app1["appid"])
+
+	app2Object := appsArray[1]
+	app2, ok := app2Object.(map[string]interface{})
+	assert.True(t, ok, "app should be a map")
+	assert.Equal(t, darkThemeExtensionID, app2["appid"])
 
 	extensionIDs = make(map[string]bool)
 	for _, appItem := range appsArray {
@@ -865,7 +901,7 @@ func TestUpdateExtensionsV4JSON(t *testing.T) {
 		extensionIDs[appMap["appid"].(string)] = true
 	}
 	assert.True(t, extensionIDs[lightThemeExtensionID], "response should include light theme extension")
-	assert.False(t, extensionIDs[darkThemeExtensionID], "response should not include dark theme extension")
+	assert.True(t, extensionIDs[darkThemeExtensionID], "response should include dark theme extension")
 
 	// Unknown extension ID goes to Google server via componentupdater proxy
 	requestBody = buildUpdateV4JSON("4.0", []AppVersionPair{


### PR DESCRIPTION
Resolves #262

# Summary
- the `app` array in response object must be rendered even if the client-claimed version is newer than the server one ([docs](https://source.chromium.org/chromium/chromium/src/+/main:docs/updater/protocol_4.md#:~:text=status%3A%20Indicates%20the%20outcome%20of%20the%20updatecheck.%20Servers%20must%20always%20send%20a%20value%20here.%20Known%20values%3A)) (resolves #262)
- the response must include information about every requested ID (applies to requests with more than one ID; [docs](https://source.chromium.org/chromium/chromium/src/+/main:docs/updater/protocol_4.md;bpv=0#:~:text=If%20an%20application%20appears%20in%20the%20request%2C%20it%20must%20have%20a%20corresponding%20acknowledgement%20in%20the%20response.))

# `"app": null` response

Simplified JSON request:

```json
{
  "request": {
    "apps": [
      {
        "appid": "cdbbhgbmjhfnhnmgeddbliobbofkgdhe",
        "version": "99999.99999.99999"
      }
    ]
  }
}

```

## Before

The latest version available to the server is `1.x.x`: 

```json
{
  "response": {
    "protocol": "4.0",
    "daystart": {
      "elapsed_days": 6780
    },
    "apps": null
  }
}
```

## After

```json
{
  "response": {
    "protocol": "4.0",
    "daystart": {
      "elapsed_days": 6780
    },
    "apps": [
      {
        "appid": "cdbbhgbmjhfnhnmgeddbliobbofkgdhe",
        "status": "ok",
        "updatecheck": {
          "status": "noupdate"
        }
      }
    ]
  }
}
```

# Missing apps in the update response

Simplified update request payload with 3 extensions inside (up-to-date, out-of-date and unknown ones):

```json
{
  "request": {
    "apps": [
      {
        "appid": "almolcgbkikkhliiibfjkohebgklegam",
        "version": "1.0.5"
      },
      {
        "appid": "eaidcpcfnepdmmhbglgjhpjdfodkdcki",
        "version": "1.0.283"
      },
      {
        "appid": "nokacnacikgbneblaikkpgkkekomkjae",
        "version": "1.2.3"
      }
    ]
  }
}
```

## Before

The last app is not included in the response even though the server should inform the client about every single `appid` submitted in the payload:

```json
{
  "response": {
    "protocol": "4.0",
    "daystart": {
      "elapsed_days": 6780
    },
    "apps": [
      {
        "appid": "almolcgbkikkhliiibfjkohebgklegam",
        "status": "ok",
        "updatecheck": {
          "status": "noupdate"
        }
      },
      {
        "appid": "eaidcpcfnepdmmhbglgjhpjdfodkdcki",
        "status": "ok",
        "updatecheck": {
          "status": "ok",
          "nextversion": "1.0.284",
          "pipelines": [] 
        }
      }
    ]
  }
}
```

## After

```json
{
  "response": {
    "protocol": "4.0",
    "daystart": {
      "elapsed_days": 6780
    },
    "apps": [
      {
        "appid": "almolcgbkikkhliiibfjkohebgklegam",
        "status": "ok",
        "updatecheck": {
          "status": "noupdate"
        }
      },
      {
        "appid": "eaidcpcfnepdmmhbglgjhpjdfodkdcki",
        "status": "ok",
        "updatecheck": {
          "status": "ok",
          "nextversion": "1.0.284",
          "pipelines": []
        }
      },
      {
        "appid": "nokacnacikgbneblaikkpgkkekomkjae",
        "status": "ok",
        "updatecheck": {
          "status": "error-unknownApplication"
        }
      }
    ]
  }
}
```